### PR TITLE
Optimize for AVX in conda builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,6 +55,7 @@ jobs:
           ./scripts/install_hpc_sdk.sh
           source setup_nv_h5.sh
         fi
+        export PERFORMING_CONDA_BUILD=True
         make api && \
         make main && \
         make install && \

--- a/src/Makefile
+++ b/src/Makefile
@@ -68,7 +68,7 @@ endif
 
 ifneq (,$(findstring pgi,$(COMPILER)))
 	ifeq ($(PERFORMING_CONDA_BUILD),True)
-		CPPFLAGS += -tp=piledriver
+		CPPFLAGS += -tp=sandybridge
 	endif
 else
 	ifeq ($(PERFORMING_CONDA_BUILD),True)

--- a/src/Makefile
+++ b/src/Makefile
@@ -68,7 +68,7 @@ endif
 
 ifneq (,$(findstring pgi,$(COMPILER)))
 	ifeq ($(PERFORMING_CONDA_BUILD),True)
-		CPPFLAGS += -tp=px
+		CPPFLAGS += -tp=piledriver
 	endif
 else
 	ifeq ($(PERFORMING_CONDA_BUILD),True)


### PR DESCRIPTION
The generic x86 target was too slow.
Most modern hardware should have AVX support.
