### PR TITLE
Use plain mkstemp() if O_NOATIME is not available

### DIFF
--- a/src/api.cpp
+++ b/src/api.cpp
@@ -17,11 +17,6 @@
 #define MMAP_FD_MASK 0x0fff
 #define MMAP_FLAG    0x1000
 
-/* O_NOATIME is defined at fcntl.h when supported */
-#ifndef O_NOATIME
-#define O_NOATIME 0
-#endif
-
 
 #define CHECK_FILE(filename, err) if(!is_file_exists(filename)) { \
                                       return err;                 \
@@ -198,8 +193,12 @@ void initialize_mat_full_no_biom_T(TMat* &result, const char* const * sample_ids
     } else {
       std::string mmap_template(mmap_dir);
       mmap_template+="/su_mmap_XXXXXX";
-      // note: mkostemp will update mmap_template in place
+      // note: mkstemp/mkostemp will update mmap_template in place
+#ifdef O_NOATIME
       int fd=mkostemp((char *) mmap_template.c_str(), O_NOATIME ); 
+#else
+      int fd=mkstemp((char *) mmap_template.c_str() );
+#endif
       if (fd<0) {
          result->matrix = NULL;
          // leave error handling to the caller


### PR DESCRIPTION
Platforms that don't have the Linux-specific `O_NOATIME` may not have the non-POSIX `mkostemp()` either.
For example, macOS prior to version 10.12 did not provide `mkostemp()`.

The code needs `mkostemp` only so that it can specify `mkostemp(…, O_NOATIME)`. If `O_NOATIME` is not available, it could equivalently use the POSIX standard `mkstemp()` instead. For your consideration, this PR does that.

See also bioconda/bioconda-recipes#37162, which applies this patch to Bioconda's unifrac-binaries package to reinstate it after previous macOS build failures due to this missing function.