### PR TITLE
Use OpenACC to detect GPU presence

### DIFF
--- a/src/unifrac.cpp
+++ b/src/unifrac.cpp
@@ -398,6 +398,12 @@ inline bool use_acc() {
    }
  }
 
+ if (has_nvidia_gpu_rc == 0) {
+    if (!su_acc::found_gpu()) {
+       has_nvidia_gpu_rc  = 1;
+       if (print_info) printf("INFO (unifrac): NVIDIA GPU listed but OpenACC cannot use it.\n");
+    }
+ } 
 
  if (has_nvidia_gpu_rc != 0) {
    if (print_info) printf("INFO (unifrac): GPU not found, using CPU\n");

--- a/src/unifrac_cmp.cpp
+++ b/src/unifrac_cmp.cpp
@@ -25,6 +25,19 @@
 
 using namespace SUCMP_NM;
 
+#ifdef _OPENACC
+#include <openacc.h>
+
+bool SUCMP_NM::found_gpu() {
+  return acc_get_device_type() != acc_device_host;
+}
+
+#else
+bool SUCMP_NM::found_gpu() {
+  return false;
+}
+#endif
+
 template<class TFloat>
 inline void initialize_sample_counts(TFloat*& _counts, const su::task_parameters* task_p, const su::biom_interface &table) {
     const unsigned int n_samples = task_p->n_samples;

--- a/src/unifrac_cmp.hpp
+++ b/src/unifrac_cmp.hpp
@@ -19,6 +19,9 @@
 
 namespace SUCMP_NM {
 
+  // Returns True iff a GPU can be used
+  bool found_gpu();
+
   void unifrac(const su::biom_interface &table,
                const su::BPTree &tree,
                su::Method unifrac_method,


### PR DESCRIPTION
An NVIDIA GPU may be present but cannot be used.
E.g. in SLURM when a GPU is not explicitly requested.
This patch uses the OpenACC function to actually check if the GPU is usable.