### PR TITLE
Add OMPGPU support (sync only for now)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, linux-gpu-cuda]
+        offload: [acc, ompgpu]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
@@ -53,6 +54,7 @@ jobs:
         fi
         df -h .
         export PERFORMING_CONDA_BUILD=True
+        export BUILD_OFFLOAD=${{ matrix.offload }}
         echo "======= begin env ====="
         env
         echo "=======  end env  ====="

--- a/src/Makefile
+++ b/src/Makefile
@@ -65,11 +65,11 @@ ifndef NOGPU
 	ifneq (,$(findstring pgi,$(COMPILER)))
 		CPPFLAGS += -DUNIFRAC_ENABLE_OMPGPU=1
                 UNIFRAC_FILES += unifrac_cmp_ompgpu.o
-		OMPGPUCPPFLAGS += -mp=gpu
+		OMPGPUCPPFLAGS += -mp=gpu -DOMPGPU=1 -noacc
 	        ifeq ($(PERFORMING_CONDA_BUILD),True)
-	            OMPGPUCPPFLAGS += -ta=tesla:ccall
+	            OMPGPUCPPFLAGS += -gpu=ccall
 		else
-	            OMPGPUCPPFLAGS += -ta=tesla
+	            OMPGPUCPPFLAGS += -gpu=ccnative
 		    # optional info
 		    OMPGPUCPPFLAGS += -Minfo=accel
                 endif

--- a/src/Makefile
+++ b/src/Makefile
@@ -61,6 +61,22 @@ CPPFLAGS += $(MPFLAG)
 UNIFRAC_FILES = unifrac_internal.o unifrac_cmp_cpu.o
 
 ifndef NOGPU
+   ifeq ($(BUILD_OFFLOAD),ompgpu)
+	ifneq (,$(findstring pgi,$(COMPILER)))
+		CPPFLAGS += -DUNIFRAC_ENABLE_OMPGPU=1
+                UNIFRAC_FILES += unifrac_cmp_ompgpu.o
+		OMPGPUCPPFLAGS += -mp=gpu
+	        ifeq ($(PERFORMING_CONDA_BUILD),True)
+	            OMPGPUCPPFLAGS += -ta=tesla:ccall
+		else
+	            OMPGPUCPPFLAGS += -ta=tesla
+		    # optional info
+		    OMPGPUCPPFLAGS += -Minfo=accel
+                endif
+	        LDDFLAGS += -shlib -mp=gpu -Bstatic_pgi
+	        EXEFLAGS += -mp=gpu -Bstatic_pgi
+	endif
+   else 
 	ifneq (,$(findstring pgi,$(COMPILER)))
 		CPPFLAGS += -DUNIFRAC_ENABLE_ACC=1
                 UNIFRAC_FILES += unifrac_cmp_acc.o
@@ -75,6 +91,7 @@ ifndef NOGPU
 	        LDDFLAGS += -shlib -acc -Bstatic_pgi
 	        EXEFLAGS += -acc -Bstatic_pgi
 	endif
+   endif
 endif
 
 ifneq ($(BUILD_FULL_OPTIMIZATION),False)
@@ -152,6 +169,8 @@ unifrac_cmp_cpu.o: unifrac_cmp.cpp unifrac_cmp.hpp unifrac_internal.hpp unifrac.
 
 unifrac_cmp_acc.o: unifrac_cmp.cpp unifrac_cmp.hpp unifrac_internal.hpp unifrac.hpp unifrac_task.cpp unifrac_task.hpp biom_interface.hpp tree.hpp
 	$(CXX) $(CPPFLAGS) $(ACCCPPFLAGS) -c $< -o $@
+unifrac_cmp_ompgpu.o: unifrac_cmp.cpp unifrac_cmp.hpp unifrac_internal.hpp unifrac.hpp unifrac_task.cpp unifrac_task.hpp biom_interface.hpp tree.hpp
+	$(CXX) $(CPPFLAGS) $(OMPGPUCPPFLAGS) -c $< -o $@
 
 %.o: %.cpp %.hpp
 	$(CXX) $(CPPFLAGS) -c $< -o $@

--- a/src/unifrac_cmp.cpp
+++ b/src/unifrac_cmp.cpp
@@ -71,7 +71,6 @@ inline void unifracTT(const su::biom_interface &table,
                       std::vector<double*> &dm_stripes,
                       std::vector<double*> &dm_stripes_total,
                       const su::task_parameters* task_p) {
-    int err;
     // no processor affinity whenusing openacc or openmp
 
     if(table.n_samples != task_p->n_samples) {
@@ -277,7 +276,6 @@ inline void unifrac_vawTT(const su::biom_interface &table,
                           std::vector<double*> &dm_stripes,
                           std::vector<double*> &dm_stripes_total,
                           const su::task_parameters* task_p) {
-    int err;
     // no processor affinity whenusing openacc or openmp
 
     if(table.n_samples != task_p->n_samples) {

--- a/src/unifrac_cmp.cpp
+++ b/src/unifrac_cmp.cpp
@@ -30,7 +30,7 @@ using namespace SUCMP_NM;
 #include <omp.h>
 
 bool SUCMP_NM::found_gpu() {
-  return omp_get_num_devices() > 0
+  return omp_get_num_devices() > 0;
 }
 
 #elif defined(_OPENACC)
@@ -104,7 +104,7 @@ inline void unifracTT(const su::biom_interface &table,
         exit(EXIT_FAILURE);
     }
 #if defined(OMPGPU)
-#pragma omp target enter data map(alloc:lengths[:filled_emb])
+#pragma omp target enter data map(alloc:lengths[:max_emb])
 #elif defined(_OPENACC)
 #pragma acc enter data create(lengths[:max_emb])
 #endif

--- a/src/unifrac_cmp.cpp
+++ b/src/unifrac_cmp.cpp
@@ -52,14 +52,7 @@ inline void initialize_sample_counts(TFloat*& _counts, const su::task_parameters
     const unsigned int n_samples = task_p->n_samples;
     const uint64_t  n_samples_r = ((n_samples + UNIFRAC_BLOCK-1)/UNIFRAC_BLOCK)*UNIFRAC_BLOCK; // round up
     const double *sample_counts = table.get_sample_counts();
-    TFloat * counts = NULL;
-    int err = 0;
-    err = posix_memalign((void **)&counts, 4096, sizeof(TFloat) * n_samples_r);
-    if(counts == NULL || err != 0) {
-        fprintf(stderr, "Failed to allocate %zd bytes, err %d; [%s]:%d\n",
-                sizeof(TFloat) * n_samples_r, err, __FILE__, __LINE__);
-        exit(EXIT_FAILURE);
-    }
+    TFloat * counts = (TFloat *) malloc(sizeof(TFloat) * n_samples_r);
     for(unsigned int i = 0; i < n_samples; i++) {
         counts[i] = sample_counts[i];
     }
@@ -97,12 +90,7 @@ inline void unifracTT(const su::biom_interface &table,
 
     TaskT taskObj(std::ref(dm_stripes), std::ref(dm_stripes_total),max_emb,task_p);
 
-    TFloat *lengths = NULL;
-    err = posix_memalign((void **)&lengths, 4096, sizeof(TFloat) * max_emb);
-    if(err != 0) {
-        fprintf(stderr, "posix_memalign(%d) failed: %d\n", sizeof(TFloat) * max_emb,  err);
-        exit(EXIT_FAILURE);
-    }
+    TFloat *lengths = (TFloat*) malloc(sizeof(TFloat) * max_emb);
 #if defined(OMPGPU)
 #pragma omp target enter data map(alloc:lengths[:max_emb])
 #elif defined(_OPENACC)
@@ -316,12 +304,7 @@ inline void unifrac_vawTT(const su::biom_interface &table,
 
     TaskT taskObj(std::ref(dm_stripes), std::ref(dm_stripes_total), sample_total_counts, max_emb, task_p);
 
-    TFloat *lengths = NULL;
-    err = posix_memalign((void **)&lengths, 4096, sizeof(TFloat) * max_emb);
-    if(err != 0) {
-        fprintf(stderr, "posix_memalign(%d) failed: %d\n", sizeof(TFloat) * max_emb, err);
-        exit(EXIT_FAILURE);
-    }
+    TFloat *lengths = (TFloat *) malloc(sizeof(TFloat) * max_emb);
 #if defined(OMPGPU)
 #pragma omp target enter data map(alloc:lengths[:max_emb])
 #elif defined(_OPENACC)

--- a/src/unifrac_cmp.cpp
+++ b/src/unifrac_cmp.cpp
@@ -197,25 +197,7 @@ inline void unifracTT(const su::biom_interface &table,
 #endif
 
     if(want_total) {
-        const uint64_t start_idx = task_p->start;
-        const uint64_t stop_idx = task_p->stop;
-
-        TFloat * const dm_stripes_buf = taskObj.dm_stripes.buf;
-        const TFloat * const dm_stripes_total_buf = taskObj.dm_stripes_total.buf;
-        const uint64_t bufels = taskObj.dm_stripes.bufels;
-
-#if defined(OMPGPU)
-#pragma omp target teams distribute parallel for simd collapse(2) map(tofrom:dm_stripes_buf[0:bufels],dm_stripes_total_buf[0:bufels])
-#elif defined(_OPENACC)
-#pragma acc parallel loop collapse(2) present(dm_stripes_buf[0:bufels],dm_stripes_total_buf[0:bufels])
-#endif
-        for(uint64_t i = start_idx; i < stop_idx; i++)
-            for(uint64_t j = 0; j < n_samples; j++) {
-                uint64_t idx = (i-start_idx)*n_samples_r+j;
-                dm_stripes_buf[idx]=dm_stripes_buf[idx]/dm_stripes_total_buf[idx];
-                // taskObj.dm_stripes[i][j] = taskObj.dm_stripes[i][j] / taskObj.dm_stripes_total[i][j];
-            }
-        
+        taskObj.compute_totals();
     }
 
 }
@@ -360,25 +342,7 @@ inline void unifrac_vawTT(const su::biom_interface &table,
 #endif
 
     if(want_total) {
-        const uint64_t start_idx = task_p->start;
-        const uint64_t stop_idx = task_p->stop;
-
-        TFloat * const dm_stripes_buf = taskObj.dm_stripes.buf;
-        const TFloat * const dm_stripes_total_buf = taskObj.dm_stripes_total.buf;
-        const uint64_t bufels = taskObj.dm_stripes.bufels;
-
-#if defined(OMPGPU)
-#pragma omp target teams distribute parallel for simd collapse(2) map(tofrom:dm_stripes_buf[0:bufels],dm_stripes_total_buf[0:bufels])
-#elif defined(_OPENACC)
-#pragma acc parallel loop collapse(2) present(dm_stripes_buf[0:bufels],dm_stripes_total_buf[0:bufels])
-#endif
-        for(uint64_t i = start_idx; i < stop_idx; i++)
-            for(uint64_t j = 0; j < n_samples; j++) {
-                uint64_t idx = (i-start_idx)*n_samples_r+j;
-                dm_stripes_buf[idx]=dm_stripes_buf[idx]/dm_stripes_total_buf[idx];
-                // taskObj.dm_stripes[i][j] = taskObj.dm_stripes[i][j] / taskObj.dm_stripes_total[i][j];
-            }
-
+        taskObj.compute_totals();
     }
 
 

--- a/src/unifrac_cmp.cpp
+++ b/src/unifrac_cmp.cpp
@@ -224,7 +224,7 @@ inline void unifracTT(const su::biom_interface &table,
     }
 
 #if defined(OMPGPU)
-#pragma target exit data map(release:lengths[:max_emb])
+#pragma target exit data map(delete:lengths[:max_emb])
 #elif defined(_OPENACC)
 #pragma acc exit data delete(lengths[:max_emb])
 #endif
@@ -399,8 +399,8 @@ inline void unifrac_vawTT(const su::biom_interface &table,
 
 
 #if defined(OMPGPU)
-#pragma target exit data map(release:lengths[:max_emb])
-#pragma target exit data map(release:sample_total_counts[:n_samples_r])
+#pragma target exit data map(delete:lengths[:max_emb])
+#pragma target exit data map(delete:sample_total_counts[:n_samples_r])
 #elif defined(_OPENACC)
 #pragma acc exit data delete(lengths[:max_emb])
 #pragma acc exit data delete(sample_total_counts[:n_samples_r])

--- a/src/unifrac_cmp.cpp
+++ b/src/unifrac_cmp.cpp
@@ -207,11 +207,12 @@ inline void unifracTT(const su::biom_interface &table,
 
         TFloat * const dm_stripes_buf = taskObj.dm_stripes.buf;
         const TFloat * const dm_stripes_total_buf = taskObj.dm_stripes_total.buf;
+        const uint64_t bufels = taskObj.dm_stripes.bufels;
 
 #if defined(OMPGPU)
-#pragma omp target teams distribute parallel for simd collapse(2) default(shared)
+#pragma omp target teams distribute parallel for simd collapse(2) map(tofrom:dm_stripes_buf[:bufels],dm_stripes_total_buf[:bufels])
 #elif defined(_OPENACC)
-#pragma acc parallel loop collapse(2) present(dm_stripes_buf,dm_stripes_total_buf)
+#pragma acc parallel loop collapse(2) present(dm_stripes_buf[:bufels],dm_stripes_total_buf[:bufels])
 #endif
         for(uint64_t i = start_idx; i < stop_idx; i++)
             for(uint64_t j = 0; j < n_samples; j++) {
@@ -380,11 +381,12 @@ inline void unifrac_vawTT(const su::biom_interface &table,
 
         TFloat * const dm_stripes_buf = taskObj.dm_stripes.buf;
         const TFloat * const dm_stripes_total_buf = taskObj.dm_stripes_total.buf;
+        const uint64_t bufels = taskObj.dm_stripes.bufels;
 
 #if defined(OMPGPU)
-#pragma omp target teams distribute parallel for simd collapse(2) default(shared)
+#pragma omp target teams distribute parallel for simd collapse(2) map(tofrom:dm_stripes_buf[:bufels],dm_stripes_total_buf[:bufels])
 #elif defined(_OPENACC)
-#pragma acc parallel loop collapse(2) present(dm_stripes_buf,dm_stripes_total_buf)
+#pragma acc parallel loop collapse(2) present(map(tofrom:dm_stripes_buf[:bufels],dm_stripes_total_buf[:bufels])
 #endif
         for(uint64_t i = start_idx; i < stop_idx; i++)
             for(uint64_t j = 0; j < n_samples; j++) {

--- a/src/unifrac_cmp.cpp
+++ b/src/unifrac_cmp.cpp
@@ -386,7 +386,7 @@ inline void unifrac_vawTT(const su::biom_interface &table,
 #if defined(OMPGPU)
 #pragma omp target teams distribute parallel for simd collapse(2) map(tofrom:dm_stripes_buf[:bufels],dm_stripes_total_buf[:bufels])
 #elif defined(_OPENACC)
-#pragma acc parallel loop collapse(2) present(map(tofrom:dm_stripes_buf[:bufels],dm_stripes_total_buf[:bufels])
+#pragma acc parallel loop collapse(2) present(dm_stripes_buf[:bufels],dm_stripes_total_buf[:bufels])
 #endif
         for(uint64_t i = start_idx; i < stop_idx; i++)
             for(uint64_t j = 0; j < n_samples; j++) {

--- a/src/unifrac_cmp.cpp
+++ b/src/unifrac_cmp.cpp
@@ -91,9 +91,9 @@ inline void unifracTT(const su::biom_interface &table,
 
     TFloat *lengths = (TFloat*) malloc(sizeof(TFloat) * max_emb);
 #if defined(OMPGPU)
-#pragma omp target enter data map(alloc:lengths[:max_emb])
+#pragma omp target enter data map(alloc:lengths[0:max_emb])
 #elif defined(_OPENACC)
-#pragma acc enter data create(lengths[:max_emb])
+#pragma acc enter data create(lengths[0:max_emb])
 #endif
 
         /*
@@ -183,11 +183,11 @@ inline void unifracTT(const su::biom_interface &table,
           taskObj.sync_embedded_proportions(filled_emb);
 #if defined(OMPGPU)
           // TODO: Change if we ever implement async in OMPGPU
-#pragma omp target update to(lengths[:filled_emb])
+#pragma omp target update to(lengths[0:filled_emb])
 #elif defined(_OPENACC)
           // lengths may be still in use in async mode, wait
 #pragma acc wait
-#pragma acc update device(lengths[:filled_emb])
+#pragma acc update device(lengths[0:filled_emb])
 #endif
           taskObj._run(filled_emb,lengths);
           filled_emb=0;
@@ -210,9 +210,9 @@ inline void unifracTT(const su::biom_interface &table,
         const uint64_t bufels = taskObj.dm_stripes.bufels;
 
 #if defined(OMPGPU)
-#pragma omp target teams distribute parallel for simd collapse(2) map(tofrom:dm_stripes_buf[:bufels],dm_stripes_total_buf[:bufels])
+#pragma omp target teams distribute parallel for simd collapse(2) map(tofrom:dm_stripes_buf[0:bufels],dm_stripes_total_buf[0:bufels])
 #elif defined(_OPENACC)
-#pragma acc parallel loop collapse(2) present(dm_stripes_buf[:bufels],dm_stripes_total_buf[:bufels])
+#pragma acc parallel loop collapse(2) present(dm_stripes_buf[0:bufels],dm_stripes_total_buf[0:bufels])
 #endif
         for(uint64_t i = start_idx; i < stop_idx; i++)
             for(uint64_t j = 0; j < n_samples; j++) {
@@ -224,9 +224,9 @@ inline void unifracTT(const su::biom_interface &table,
     }
 
 #if defined(OMPGPU)
-#pragma target exit data map(delete:lengths[:max_emb])
+#pragma target exit data map(delete:lengths[0:max_emb])
 #elif defined(_OPENACC)
-#pragma acc exit data delete(lengths[:max_emb])
+#pragma acc exit data delete(lengths[0:max_emb])
 #endif
     free(lengths);
 }
@@ -295,9 +295,9 @@ inline void unifrac_vawTT(const su::biom_interface &table,
 
     initialize_sample_counts(sample_total_counts, task_p, table);
 #if defined(OMPGPU)
-#pragma omp target enter data map(to:sample_total_counts[:n_samples_r])
+#pragma omp target enter data map(to:sample_total_counts[0:n_samples_r])
 #elif defined(_OPENACC)
-#pragma acc enter data copyin(sample_total_counts[:n_samples_r])
+#pragma acc enter data copyin(sample_total_counts[0:n_samples_r])
 #endif
     su::initialize_stripes(std::ref(dm_stripes), std::ref(dm_stripes_total), want_total, task_p);
 
@@ -305,9 +305,9 @@ inline void unifrac_vawTT(const su::biom_interface &table,
 
     TFloat *lengths = (TFloat *) malloc(sizeof(TFloat) * max_emb);
 #if defined(OMPGPU)
-#pragma omp target enter data map(alloc:lengths[:max_emb])
+#pragma omp target enter data map(alloc:lengths[0:max_emb])
 #elif defined(_OPENACC)
-#pragma acc enter data create(lengths[:max_emb])
+#pragma acc enter data create(lengths[0:max_emb])
 #endif
 
     unsigned int k = 0; // index in tree
@@ -355,11 +355,11 @@ inline void unifrac_vawTT(const su::biom_interface &table,
 
 #if defined(OMPGPU)
           // TODO: Change if we ever implement async in OMPGPU
-#pragma omp target update to(lengths[:filled_emb])
+#pragma omp target update to(lengths[0:filled_emb])
 #elif defined(_OPENACC)
           // lengths may be still in use in async mode, wait
 #pragma acc wait
-#pragma acc update device(lengths[:filled_emb])
+#pragma acc update device(lengths[0:filled_emb])
 #endif
 
           taskObj.sync_embedded(filled_emb);
@@ -384,9 +384,9 @@ inline void unifrac_vawTT(const su::biom_interface &table,
         const uint64_t bufels = taskObj.dm_stripes.bufels;
 
 #if defined(OMPGPU)
-#pragma omp target teams distribute parallel for simd collapse(2) map(tofrom:dm_stripes_buf[:bufels],dm_stripes_total_buf[:bufels])
+#pragma omp target teams distribute parallel for simd collapse(2) map(tofrom:dm_stripes_buf[0:bufels],dm_stripes_total_buf[0:bufels])
 #elif defined(_OPENACC)
-#pragma acc parallel loop collapse(2) present(dm_stripes_buf[:bufels],dm_stripes_total_buf[:bufels])
+#pragma acc parallel loop collapse(2) present(dm_stripes_buf[0:bufels],dm_stripes_total_buf[0:bufels])
 #endif
         for(uint64_t i = start_idx; i < stop_idx; i++)
             for(uint64_t j = 0; j < n_samples; j++) {
@@ -399,11 +399,11 @@ inline void unifrac_vawTT(const su::biom_interface &table,
 
 
 #if defined(OMPGPU)
-#pragma target exit data map(delete:lengths[:max_emb])
-#pragma target exit data map(delete:sample_total_counts[:n_samples_r])
+#pragma target exit data map(delete:lengths[0:max_emb])
+#pragma target exit data map(delete:sample_total_counts[0:n_samples_r])
 #elif defined(_OPENACC)
-#pragma acc exit data delete(lengths[:max_emb])
-#pragma acc exit data delete(sample_total_counts[:n_samples_r])
+#pragma acc exit data delete(lengths[0:max_emb])
+#pragma acc exit data delete(sample_total_counts[0:n_samples_r])
 #endif
     free(lengths);
     free(sample_total_counts);

--- a/src/unifrac_task.cpp
+++ b/src/unifrac_task.cpp
@@ -417,13 +417,14 @@ static inline void UnnormalizedWeighted8(
 #endif
 
 template<class TFloat>
-void SUCMP_NM::UnifracUnnormalizedWeightedTask<TFloat>::_run(unsigned int filled_embs, const TFloat * __restrict__ lengths) {
+void SUCMP_NM::UnifracUnnormalizedWeightedTask<TFloat>::_run(unsigned int filled_embs) {
     const uint64_t start_idx = this->task_p->start;
     const uint64_t stop_idx = this->task_p->stop;
     const uint64_t n_samples = this->task_p->n_samples;
     const uint64_t n_samples_r = this->dm_stripes.n_samples_r;
 
     // openacc only works well with local variables
+    const TFloat * const __restrict__ lengths = this->lengths;
     const TFloat * const __restrict__ embedded_proportions = this->embedded_proportions;
     TFloat * const __restrict__ dm_stripes_buf = this->dm_stripes.buf;
 
@@ -530,13 +531,14 @@ void SUCMP_NM::UnifracUnnormalizedWeightedTask<TFloat>::_run(unsigned int filled
 }
 
 template<class TFloat>
-void SUCMP_NM::UnifracVawUnnormalizedWeightedTask<TFloat>::_run(unsigned int filled_embs, const TFloat * __restrict__ lengths) {
+void SUCMP_NM::UnifracVawUnnormalizedWeightedTask<TFloat>::_run(unsigned int filled_embs) {
     const uint64_t start_idx = this->task_p->start;
     const uint64_t stop_idx = this->task_p->stop;
     const uint64_t n_samples = this->task_p->n_samples;
     const uint64_t n_samples_r = this->dm_stripes.n_samples_r;
 
     // openacc only works well with local variables
+    const TFloat * const __restrict__ lengths = this->lengths;
     const TFloat * const __restrict__ embedded_proportions = this->embedded_proportions;
     const TFloat * const __restrict__ embedded_counts = this->embedded_counts;
     const TFloat * const __restrict__ sample_total_counts = this->sample_total_counts;
@@ -877,13 +879,14 @@ static inline void NormalizedWeighted8(
 #endif
 
 template<class TFloat>
-void SUCMP_NM::UnifracNormalizedWeightedTask<TFloat>::_run(unsigned int filled_embs, const TFloat * __restrict__ lengths) {
+void SUCMP_NM::UnifracNormalizedWeightedTask<TFloat>::_run(unsigned int filled_embs) {
     const uint64_t start_idx = this->task_p->start;
     const uint64_t stop_idx = this->task_p->stop;
     const uint64_t n_samples = this->task_p->n_samples;
     const uint64_t n_samples_r = this->dm_stripes.n_samples_r;
 
     // openacc only works well with local variables
+    const TFloat * const __restrict__ lengths = this->lengths;
     const TFloat * const __restrict__ embedded_proportions = this->embedded_proportions;
     TFloat * const __restrict__ dm_stripes_buf = this->dm_stripes.buf;
     TFloat * const __restrict__ dm_stripes_total_buf = this->dm_stripes_total.buf;
@@ -991,13 +994,14 @@ void SUCMP_NM::UnifracNormalizedWeightedTask<TFloat>::_run(unsigned int filled_e
 }
 
 template<class TFloat>
-void SUCMP_NM::UnifracVawNormalizedWeightedTask<TFloat>::_run(unsigned int filled_embs, const TFloat * __restrict__ lengths) {
+void SUCMP_NM::UnifracVawNormalizedWeightedTask<TFloat>::_run(unsigned int filled_embs) {
     const uint64_t start_idx = this->task_p->start;
     const uint64_t stop_idx = this->task_p->stop;
     const uint64_t n_samples = this->task_p->n_samples;
     const uint64_t n_samples_r = this->dm_stripes.n_samples_r;
 
     // openacc only works well with local variables
+    const TFloat * const __restrict__ lengths = this->lengths;
     const TFloat * const __restrict__ embedded_proportions = this->embedded_proportions;
     const TFloat * const __restrict__ embedded_counts = this->embedded_counts;
     const TFloat * const __restrict__ sample_total_counts = this->sample_total_counts;
@@ -1075,13 +1079,14 @@ void SUCMP_NM::UnifracVawNormalizedWeightedTask<TFloat>::_run(unsigned int fille
 }
 
 template<class TFloat>
-void SUCMP_NM::UnifracGeneralizedTask<TFloat>::_run(unsigned int filled_embs, const TFloat * __restrict__ lengths) {
+void SUCMP_NM::UnifracGeneralizedTask<TFloat>::_run(unsigned int filled_embs) {
     const uint64_t start_idx = this->task_p->start;
     const uint64_t stop_idx = this->task_p->stop;
     const uint64_t n_samples = this->task_p->n_samples;
     const uint64_t n_samples_r = this->dm_stripes.n_samples_r;
 
     // openacc only works well with local variables
+    const TFloat * const __restrict__ lengths = this->lengths;
     const TFloat * const __restrict__ embedded_proportions = this->embedded_proportions;
     TFloat * const __restrict__ dm_stripes_buf = this->dm_stripes.buf;
     TFloat * const __restrict__ dm_stripes_total_buf = this->dm_stripes_total.buf;
@@ -1157,7 +1162,7 @@ void SUCMP_NM::UnifracGeneralizedTask<TFloat>::_run(unsigned int filled_embs, co
 }
 
 template<class TFloat>
-void SUCMP_NM::UnifracVawGeneralizedTask<TFloat>::_run(unsigned int filled_embs, const TFloat * __restrict__ lengths) {
+void SUCMP_NM::UnifracVawGeneralizedTask<TFloat>::_run(unsigned int filled_embs) {
     const uint64_t start_idx = this->task_p->start;
     const uint64_t stop_idx = this->task_p->stop;
     const uint64_t n_samples = this->task_p->n_samples;
@@ -1166,6 +1171,7 @@ void SUCMP_NM::UnifracVawGeneralizedTask<TFloat>::_run(unsigned int filled_embs,
     const TFloat g_unifrac_alpha = this->task_p->g_unifrac_alpha;
 
     // openacc only works well with local variables
+    const TFloat * const __restrict__ lengths = this->lengths;
     const TFloat * const __restrict__ embedded_proportions = this->embedded_proportions;
     const TFloat * const __restrict__ embedded_counts = this->embedded_counts;
     const TFloat * const __restrict__ sample_total_counts = this->sample_total_counts;
@@ -1562,13 +1568,14 @@ static inline void UnweightedZerosAndSums(
 }
 
 template<class TFloat>
-void SUCMP_NM::UnifracUnweightedTask<TFloat>::_run(unsigned int filled_embs, const TFloat * __restrict__ lengths) {
+void SUCMP_NM::UnifracUnweightedTask<TFloat>::_run(unsigned int filled_embs) {
     const uint64_t start_idx = this->task_p->start;
     const uint64_t stop_idx = this->task_p->stop;
     const uint64_t n_samples = this->task_p->n_samples;
     const uint64_t n_samples_r = this->dm_stripes.n_samples_r;
 
     // openacc only works well with local variables
+    const TFloat * const __restrict__ lengths = this->lengths;
     const uint64_t * const __restrict__ embedded_proportions = this->embedded_proportions;
     TFloat * const __restrict__ dm_stripes_buf = this->dm_stripes.buf;
     TFloat * const __restrict__ dm_stripes_total_buf = this->dm_stripes_total.buf;
@@ -1731,13 +1738,14 @@ void SUCMP_NM::UnifracUnweightedTask<TFloat>::_run(unsigned int filled_embs, con
 }
 
 template<class TFloat>
-void SUCMP_NM::UnifracVawUnweightedTask<TFloat>::_run(unsigned int filled_embs, const TFloat * __restrict__ lengths) {
+void SUCMP_NM::UnifracVawUnweightedTask<TFloat>::_run(unsigned int filled_embs) {
     const uint64_t start_idx = this->task_p->start;
     const uint64_t stop_idx = this->task_p->stop;
     const uint64_t n_samples = this->task_p->n_samples;
     const uint64_t n_samples_r = this->dm_stripes.n_samples_r;
 
     // openacc only works well with local variables
+    const TFloat * const __restrict__ lengths = this->lengths;
     const uint32_t * const __restrict__ embedded_proportions = this->embedded_proportions;
     const TFloat  * const __restrict__ embedded_counts = this->embedded_counts;
     const TFloat  * const __restrict__ sample_total_counts = this->sample_total_counts;

--- a/src/unifrac_task.cpp
+++ b/src/unifrac_task.cpp
@@ -1589,7 +1589,7 @@ void SUCMP_NM::UnifracUnweightedTask<TFloat>::_run(unsigned int filled_embs, con
     // We will use a 8-bit map, to keep it small enough to keep in L1 cache
 #if defined(OMPGPU)
     // TODO: Explore async omp target
-#pragma omp target teams distribute collapse(2) default(shared)
+#pragma omp target teams distribute parallel for collapse(2) default(shared)
 #elif defined(_OPENACC)
 #pragma acc parallel loop collapse(2) gang present(lengths,sums) async
 #else 
@@ -1602,7 +1602,7 @@ void SUCMP_NM::UnifracUnweightedTask<TFloat>::_run(unsigned int filled_embs, con
           const TFloat * __restrict__ pl   = &(lengths[emb8*8]);
 
 #if defined(OMPGPU)
-#pragma omp parallel for simd
+#pragma omp simd
 #elif defined(_OPENACC)
 #pragma acc loop vector
 #endif
@@ -1625,7 +1625,7 @@ void SUCMP_NM::UnifracUnweightedTask<TFloat>::_run(unsigned int filled_embs, con
     if (filled_embs_rem>0) { // add also the overflow elements
        const uint64_t emb_el=filled_embs_els;
 #if defined(OMPGPU)
-#pragma omp target teams distribute default(shared)
+#pragma omp target teams distribute parallel for default(shared)
 #elif defined(_OPENACC)
 #pragma acc parallel loop gang present(lengths,sums) async
 #else
@@ -1637,7 +1637,7 @@ void SUCMP_NM::UnifracUnweightedTask<TFloat>::_run(unsigned int filled_embs, con
           TFloat * __restrict__ psum = &(sums[emb8<<8]);
 
 #if defined(OMPGPU)
-#pragma omp parallel for simd
+#pragma omp simd
 #elif defined(_OPENACC)
 #pragma acc loop vector
 #endif

--- a/src/unifrac_task.cpp
+++ b/src/unifrac_task.cpp
@@ -983,6 +983,8 @@ void SUCMP_NM::UnifracNormalizedWeightedTask<TFloat>::_run(unsigned int filled_e
     } // for ss
 #endif
 
+   // next iteration will use the alternative space
+   this->set_alt_embedded_proportions();
 }
 
 template<class TFloat>

--- a/src/unifrac_task.cpp
+++ b/src/unifrac_task.cpp
@@ -2,7 +2,9 @@
 #include "unifrac_task.hpp"
 #include <cstdlib>
 
-#ifndef _OPENACC
+#if defined(_OPENACC) || defined(OMPGPU)
+// will not use popcnt for accelerated compute
+#else
 // popcnt returns number of bits set to 1, if supported by fast HW compute
 // else return 0 when v is 0 and max-bits else
 // Note: The user of popcnt in this file must be able to use this modified semantics
@@ -17,6 +19,7 @@ static inline int64_t popcnt_u64(uint64_t v) {return (v==0) ? 0 : 64;}
 // For future non-x86 ports, see https://barakmich.dev/posts/popcnt-arm64-go-asm/
 // and https://stackoverflow.com/questions/38113284/whats-the-difference-between-builtin-popcountll-and-mm-popcnt-u64
 #endif
+
 #endif
 
 // check for zero values and pre-compute single column sums
@@ -29,7 +32,9 @@ static inline void WeightedZerosAndSums(
                       const unsigned int filled_embs,
                       const uint64_t n_samples,
                       const uint64_t n_samples_r) {
-#ifdef _OPENACC
+#if defined(OMPGPU)
+#pragma omp target teams distribute parallel for simd default(shared)
+#elif defined(_OPENACC)
 #pragma acc parallel loop gang vector present(embedded_proportions,lengths,zcheck,sums)
 #else
 #pragma omp parallel for default(shared)
@@ -38,7 +43,9 @@ static inline void WeightedZerosAndSums(
             bool all_zeros=true;
             TFloat my_sum = 0.0;
 
+#if !defined(OMPGPU) && defined(_OPENACC)
 #pragma acc loop seq
+#endif
             for (uint64_t emb=0; emb<filled_embs; emb++) {
                 const uint64_t offset = n_samples_r * emb;
 
@@ -77,7 +84,7 @@ static inline TFloat WeightedVal1(
             return my_stripe;
 }
 
-#ifndef _OPENACC
+#if !(defined(_OPENACC) || defined(OMPGPU))
 template<class TFloat>
 static inline void WeightedVal4(
                       TFloat * const __restrict__ stripes,
@@ -248,7 +255,7 @@ static inline void UnnormalizedWeighted1(
        }
 }
 
-#ifndef _OPENACC
+#if !(defined(_OPENACC) || defined(OMPGPU))
 // Vectorized step in computing UnnormalizedWeighted Unifrac
 template<class TFloat>
 static inline void UnnormalizedWeighted4(
@@ -432,9 +439,15 @@ void SUCMP_NM::UnifracUnnormalizedWeightedTask<TFloat>::_run(unsigned int filled
                          filled_embs, n_samples, n_samples_r);
 
     // now do the real compute
-#ifdef _OPENACC
+#if defined(_OPENACC) || defined(OMPGPU)
     const unsigned int acc_vector_size = SUCMP_NM::UnifracUnnormalizedWeightedTask<TFloat>::acc_vector_size;
+
+#if defined(OMPGPU)
+    // TODO: Explore async omp target
+#pragma omp target teams distribute parallel for simd collapse(3) simdlen(acc_vector_size) default(shared)
+#else
 #pragma acc parallel loop gang vector collapse(3) vector_length(acc_vector_size) present(embedded_proportions,dm_stripes_buf,lengths,zcheck,sums) async
+#endif
     for(uint64_t sk = 0; sk < sample_steps ; sk++) {
      for(uint64_t stripe = start_idx; stripe < stop_idx; stripe++) {
       // SIMT-based GPU work great one at a time (HW will deal with parallelism)
@@ -510,7 +523,7 @@ void SUCMP_NM::UnifracUnnormalizedWeightedTask<TFloat>::_run(unsigned int filled
     } // for ss
 #endif
 
-#ifdef _OPENACC
+#if defined(_OPENACC) || defined(OMPGPU)
    // next iteration will use the alternative space
    std::swap(this->embedded_proportions,this->embedded_proportions_alt);
 #endif
@@ -533,9 +546,16 @@ void SUCMP_NM::UnifracVawUnnormalizedWeightedTask<TFloat>::_run(unsigned int fil
     const uint64_t sample_steps = (n_samples+(step_size-1))/step_size; // round up
 
     // point of thread
-#ifdef _OPENACC
+#if defined(_OPENACC) || defined(OMPGPU)
     const unsigned int acc_vector_size = SUCMP_NM::UnifracVawUnnormalizedWeightedTask<TFloat>::acc_vector_size;
+
+#if defined(OMPGPU)
+    // TODO: Explore async omp target
+#pragma omp target teams distribute parallel for simd collapse(3) simdlen(acc_vector_size) default(shared)
+#else
 #pragma acc parallel loop collapse(3) vector_length(acc_vector_size) present(embedded_proportions,embedded_counts,sample_total_counts,dm_stripes_buf,lengths) async
+#endif
+
 #else
 #pragma omp parallel for default(shared) schedule(dynamic,1)
 #endif
@@ -555,7 +575,9 @@ void SUCMP_NM::UnifracVawUnnormalizedWeightedTask<TFloat>::_run(unsigned int fil
 
             TFloat my_stripe = dm_stripe[k];
 
+#if !defined(OMPGPU) && defined(_OPENACC)
 #pragma acc loop seq
+#endif
             for (uint64_t emb=0; emb<filled_embs; emb++) {
                 const uint64_t offset = n_samples_r*emb;
 
@@ -578,7 +600,7 @@ void SUCMP_NM::UnifracVawUnnormalizedWeightedTask<TFloat>::_run(unsigned int fil
       }
     }
 
-#ifdef _OPENACC
+#if defined(_OPENACC) || defined(OMPGPU)
    // next iteration will use the alternative space
    std::swap(this->embedded_proportions,this->embedded_proportions_alt);
 #endif
@@ -635,7 +657,7 @@ static inline void NormalizedWeighted1(
        }
 }
 
-#ifndef _OPENACC
+#if !(defined(_OPENACC) || defined(OMPGPU))
 // Vectorized step in computing NormalizedWeighted Unifrac
 template<class TFloat>
 static inline void NormalizedWeighted4(
@@ -878,9 +900,15 @@ void SUCMP_NM::UnifracNormalizedWeightedTask<TFloat>::_run(unsigned int filled_e
                          filled_embs, n_samples, n_samples_r);
 
     // point of thread
-#ifdef _OPENACC
+#if defined(_OPENACC) || defined(OMPGPU)
     const unsigned int acc_vector_size = SUCMP_NM::UnifracNormalizedWeightedTask<TFloat>::acc_vector_size;
+
+#if defined(OMPGPU)
+    // TODO: Explore async omp target
+#pragma omp target teams distribute parallel for simd collapse(3) simdlen(acc_vector_size) default(shared)
+#else
 #pragma acc parallel loop gang vector collapse(3) vector_length(acc_vector_size) present(embedded_proportions,dm_stripes_buf,dm_stripes_total_buf,lengths,zcheck,sums) async
+#endif
     for(uint64_t sk = 0; sk < sample_steps ; sk++) {
      for(uint64_t stripe = start_idx; stripe < stop_idx; stripe++) {
       // SIMT-based GPU work great one at a time (HW will deal with parallelism)
@@ -956,7 +984,7 @@ void SUCMP_NM::UnifracNormalizedWeightedTask<TFloat>::_run(unsigned int filled_e
     } // for ss
 #endif
 
-#ifdef _OPENACC
+#if defined(_OPENACC) || defined(OMPGPU)
    // next iteration will use the alternative space
    std::swap(this->embedded_proportions,this->embedded_proportions_alt);
 #endif
@@ -980,9 +1008,16 @@ void SUCMP_NM::UnifracVawNormalizedWeightedTask<TFloat>::_run(unsigned int fille
     const uint64_t sample_steps = (n_samples+(step_size-1))/step_size; // round up
 
     // point of thread
-#ifdef _OPENACC
+#if defined(_OPENACC) || defined(OMPGPU)
     const unsigned int acc_vector_size = SUCMP_NM::UnifracVawNormalizedWeightedTask<TFloat>::acc_vector_size;
+
+#if defined(OMPGPU)
+    // TODO: Explore async omp target
+#pragma omp target teams distribute parallel for simd collapse(3) simdlen(acc_vector_size) default(shared)
+#else
 #pragma acc parallel loop collapse(3) vector_length(acc_vector_size) present(embedded_proportions,embedded_counts,sample_total_counts,dm_stripes_buf,dm_stripes_total_buf,lengths) async
+#endif
+
 #else
 #pragma omp parallel for schedule(dynamic,1) default(shared)
 #endif
@@ -1005,7 +1040,9 @@ void SUCMP_NM::UnifracVawNormalizedWeightedTask<TFloat>::_run(unsigned int fille
             TFloat my_stripe = dm_stripe[k];
             TFloat my_stripe_total = dm_stripe_total[k];
 
+#if !defined(OMPGPU) && defined(_OPENACC)
 #pragma acc loop seq
+#endif
             for (uint64_t emb=0; emb<filled_embs; emb++) {
                 const uint64_t offset = n_samples_r * emb;
 
@@ -1031,7 +1068,7 @@ void SUCMP_NM::UnifracVawNormalizedWeightedTask<TFloat>::_run(unsigned int fille
       }
     }
 
-#ifdef _OPENACC
+#if defined(_OPENACC) || defined(OMPGPU)
    // next iteration will use the alternative space
    std::swap(this->embedded_proportions,this->embedded_proportions_alt);
 #endif
@@ -1055,9 +1092,16 @@ void SUCMP_NM::UnifracGeneralizedTask<TFloat>::_run(unsigned int filled_embs, co
     const uint64_t sample_steps = (n_samples+(step_size-1))/step_size; // round up
 
     // point of thread
-#ifdef _OPENACC
+#if defined(_OPENACC) || defined(OMPGPU)
     const unsigned int acc_vector_size = SUCMP_NM::UnifracGeneralizedTask<TFloat>::acc_vector_size;
+
+#if defined(OMPGPU)
+    // TODO: Explore async omp target
+#pragma omp target teams distribute parallel for simd collapse(3) simdlen(acc_vector_size) default(shared)
+#else
 #pragma acc parallel loop collapse(3) vector_length(acc_vector_size) present(embedded_proportions,dm_stripes_buf,dm_stripes_total_buf,lengths) async
+#endif
+
 #else
 #pragma omp parallel for schedule(dynamic,1) default(shared)
 #endif
@@ -1078,7 +1122,9 @@ void SUCMP_NM::UnifracGeneralizedTask<TFloat>::_run(unsigned int filled_embs, co
             TFloat my_stripe = dm_stripe[k];
             TFloat my_stripe_total = dm_stripe_total[k];
 
+#if !defined(OMPGPU) && defined(_OPENACC)
 #pragma acc loop seq
+#endif
             for (uint64_t emb=0; emb<filled_embs; emb++) {
                 const uint64_t offset = n_samples_r * emb;
 
@@ -1104,7 +1150,7 @@ void SUCMP_NM::UnifracGeneralizedTask<TFloat>::_run(unsigned int filled_embs, co
       }
     }
 
-#ifdef _OPENACC
+#if defined(_OPENACC) || defined(OMPGPU)
    // next iteration will use the alternative space
    std::swap(this->embedded_proportions,this->embedded_proportions_alt);
 #endif
@@ -1131,9 +1177,16 @@ void SUCMP_NM::UnifracVawGeneralizedTask<TFloat>::_run(unsigned int filled_embs,
     // quick hack, to be finished
 
     // point of thread
-#ifdef _OPENACC
+#if defined(_OPENACC) || defined(OMPGPU)
     const unsigned int acc_vector_size = SUCMP_NM::UnifracVawGeneralizedTask<TFloat>::acc_vector_size;
+
+#if defined(OMPGPU)
+    // TODO: Explore async omp target
+#pragma omp target teams distribute parallel for simd collapse(3) simdlen(acc_vector_size) default(shared)
+#else
 #pragma acc parallel loop collapse(3) vector_length(acc_vector_size) present(embedded_proportions,embedded_counts,sample_total_counts,dm_stripes_buf,dm_stripes_total_buf,lengths) async
+#endif
+
 #else
 #pragma omp parallel for schedule(dynamic,1) default(shared)
 #endif
@@ -1156,7 +1209,9 @@ void SUCMP_NM::UnifracVawGeneralizedTask<TFloat>::_run(unsigned int filled_embs,
             TFloat my_stripe = dm_stripe[k];
             TFloat my_stripe_total = dm_stripe_total[k];
 
+#if !defined(OMPGPU) && defined(_OPENACC)
 #pragma acc loop seq
+#endif
             for (uint64_t emb=0; emb<filled_embs; emb++) {
                 const uint64_t offset = n_samples_r * emb;
 
@@ -1184,7 +1239,7 @@ void SUCMP_NM::UnifracVawGeneralizedTask<TFloat>::_run(unsigned int filled_embs,
       }
     }
 
-#ifdef _OPENACC
+#if defined(_OPENACC) || defined(OMPGPU)
    // next iteration will use the alternative space
    std::swap(this->embedded_proportions,this->embedded_proportions_alt);
 #endif
@@ -1214,7 +1269,7 @@ static inline void UnweightedOneSide(
                     // nothing to do
                 } else {
                  all_zeros = false;
-#ifndef _OPENACC
+#if !(defined(_OPENACC) || defined(OMPGPU))
                  // CPU/SIMD faster if we check for partial compute
                  if (((uint32_t)o1)==0) {
                     // only high part relevant
@@ -1277,7 +1332,7 @@ static inline void UnweightedOneSide(
 
 }
 
-#ifdef _OPENACC
+#if defined(_OPENACC) || defined(OMPGPU)
 
 template<class TFloat>
 static inline void Unweighted1(
@@ -1490,7 +1545,9 @@ static inline void UnweightedZerosAndSums(
                       const unsigned int filled_embs_els_round,
                       const uint64_t n_samples,
                       const uint64_t n_samples_r) {
-#ifdef _OPENACC
+#if defined(OMPGPU)
+#pragma omp target teams distribute parallel for simd default(shared)
+#elif defined(_OPENACC)
 #pragma acc parallel loop gang vector present(embedded_proportions,zcheck,el_sums,stripe_sums)
 #else
 #pragma omp parallel for default(shared)
@@ -1530,7 +1587,10 @@ void SUCMP_NM::UnifracUnweightedTask<TFloat>::_run(unsigned int filled_embs, con
 
     // pre-compute sums of length elements, since they are likely to be accessed many times
     // We will use a 8-bit map, to keep it small enough to keep in L1 cache
-#ifdef _OPENACC
+#if defined(OMPGPU)
+    // TODO: Explore async omp target
+#pragma omp target teams distribute collapse(2) default(shared)
+#elif defined(_OPENACC)
 #pragma acc parallel loop collapse(2) gang present(lengths,sums) async
 #else 
 #pragma omp parallel for default(shared)
@@ -1541,7 +1601,11 @@ void SUCMP_NM::UnifracUnweightedTask<TFloat>::_run(unsigned int filled_embs, con
           TFloat * __restrict__ psum = &(sums[emb8<<8]);
           const TFloat * __restrict__ pl   = &(lengths[emb8*8]);
 
+#if defined(OMPGPU)
+#pragma omp parallel for simd
+#elif defined(_OPENACC)
 #pragma acc loop vector
+#endif
           // compute all the combinations for this block (8-bits total)
           // psum[0] = 0.0   // +0*pl[0]+0*pl[1]+0*pl[2]+...
           // psum[1] = pl[0] // +0*pl[1]+0*pl[2]+...
@@ -1560,7 +1624,9 @@ void SUCMP_NM::UnifracUnweightedTask<TFloat>::_run(unsigned int filled_embs, con
     }
     if (filled_embs_rem>0) { // add also the overflow elements
        const uint64_t emb_el=filled_embs_els;
-#ifdef _OPENACC
+#if defined(OMPGPU)
+#pragma omp target teams distribute default(shared)
+#elif defined(_OPENACC)
 #pragma acc parallel loop gang present(lengths,sums) async
 #else
        // no advantage of OMP, too small
@@ -1570,7 +1636,11 @@ void SUCMP_NM::UnifracUnweightedTask<TFloat>::_run(unsigned int filled_embs, con
           const uint64_t emb8 = emb_el*8+sub8;
           TFloat * __restrict__ psum = &(sums[emb8<<8]);
 
+#if defined(OMPGPU)
+#pragma omp parallel for simd
+#elif defined(_OPENACC)
 #pragma acc loop vector
+#endif
           // compute all the combinations for this block, set to 0 any past the limit
           // as above
           for (uint64_t b8_i=0; b8_i<0x100; b8_i++) {
@@ -1583,16 +1653,24 @@ void SUCMP_NM::UnifracUnweightedTask<TFloat>::_run(unsigned int filled_embs, con
         }
     }
 
+#if !defined(OMPGPU) && defined(_OPENACC)
 #pragma acc wait
+#endif
     // check for zero values and compute stripe sums
     UnweightedZerosAndSums(zcheck, stripe_sums,
                            sums, embedded_proportions,
                            filled_embs_els_round, n_samples, n_samples_r);
 
     // point of thread
-#ifdef _OPENACC
+#if defined(_OPENACC) || defined(OMPGPU)
     const unsigned int acc_vector_size = SUCMP_NM::UnifracUnweightedTask<TFloat>::acc_vector_size;
+
+#if defined(OMPGPU)
+    // TODO: Explore async omp target
+#pragma omp target teams distribute parallel for simd collapse(3) simdlen(acc_vector_size) default(shared)
+#else
 #pragma acc parallel loop collapse(3) gang vector vector_length(acc_vector_size) present(embedded_proportions,dm_stripes_buf,dm_stripes_total_buf,sums,zcheck,stripe_sums) async
+#endif
     for(uint64_t sk = 0; sk < sample_steps ; sk++) {
       for(uint64_t stripe = start_idx; stripe < stop_idx; stripe++) {
         for(uint64_t ik = 0; ik < step_size ; ik++) {
@@ -1646,7 +1724,7 @@ void SUCMP_NM::UnifracUnweightedTask<TFloat>::_run(unsigned int filled_embs, con
     } // for ss
 #endif
 
-#ifdef _OPENACC
+#if defined(_OPENACC) || defined(OMPGPU)
    // next iteration will use the alternative space
    std::swap(this->embedded_proportions,this->embedded_proportions_alt);
 #endif
@@ -1672,9 +1750,16 @@ void SUCMP_NM::UnifracVawUnweightedTask<TFloat>::_run(unsigned int filled_embs, 
     const uint64_t filled_embs_els = (filled_embs+31)/32; // round up
 
     // point of thread
-#ifdef _OPENACC
+#if defined(_OPENACC) || defined(OMPGPU)
     const unsigned int acc_vector_size = SUCMP_NM::UnifracVawUnweightedTask<TFloat>::acc_vector_size;
+
+#if defined(OMPGPU)
+    // TODO: Explore async omp target
+#pragma omp target teams distribute parallel for simd collapse(3) simdlen(acc_vector_size) default(shared)
+#else
 #pragma acc parallel loop collapse(3) vector_length(acc_vector_size) present(embedded_proportions,embedded_counts,sample_total_counts,dm_stripes_buf,dm_stripes_total_buf,lengths) async
+#endif
+
 #else
 #pragma omp parallel for schedule(dynamic,1) default(shared)
 #endif
@@ -1697,7 +1782,9 @@ void SUCMP_NM::UnifracVawUnweightedTask<TFloat>::_run(unsigned int filled_embs, 
 
             const TFloat m = sample_total_counts[k] + sample_total_counts[l1];
 
+#if !defined(OMPGPU) && defined(_OPENACC)
 #pragma acc loop seq
+#endif
             for (uint64_t emb_el=0; emb_el<filled_embs_els; emb_el++) {
                 const uint64_t offset_p = n_samples_r * emb_el;
                 uint32_t u1 = embedded_proportions[offset_p + k];
@@ -1707,7 +1794,9 @@ void SUCMP_NM::UnifracVawUnweightedTask<TFloat>::_run(unsigned int filled_embs, 
 
                 // embedded_proporions is packed
 
+#if !defined(OMPGPU) && defined(_OPENACC)
 #pragma acc loop seq
+#endif
                 for (uint64_t ei=0; ei<32; ei++) {
                    uint64_t emb=emb_el*32+ei;
                    if (emb<filled_embs) {
@@ -1736,7 +1825,7 @@ void SUCMP_NM::UnifracVawUnweightedTask<TFloat>::_run(unsigned int filled_embs, 
       }
     }
 
-#ifdef _OPENACC
+#if defined(_OPENACC) || defined(OMPGPU)
    // next iteration will use the alternative space
    std::swap(this->embedded_proportions,this->embedded_proportions_alt);
 #endif

--- a/src/unifrac_task.cpp
+++ b/src/unifrac_task.cpp
@@ -425,7 +425,7 @@ void SUCMP_NM::UnifracUnnormalizedWeightedTask<TFloat>::_run(unsigned int filled
 
     // openacc only works well with local variables
     const TFloat * const __restrict__ lengths = this->lengths;
-    const TFloat * const __restrict__ embedded_proportions = this->embedded_proportions;
+    const TFloat * const __restrict__ embedded_proportions = this->get_embedded_proportions();
     TFloat * const __restrict__ dm_stripes_buf = this->dm_stripes.buf;
 
     bool * const __restrict__ zcheck = this->zcheck;
@@ -524,10 +524,8 @@ void SUCMP_NM::UnifracUnnormalizedWeightedTask<TFloat>::_run(unsigned int filled
     } // for ss
 #endif
 
-#if defined(_OPENACC) || defined(OMPGPU)
    // next iteration will use the alternative space
-   std::swap(this->embedded_proportions,this->embedded_proportions_alt);
-#endif
+   this->set_alt_embedded_proportions();
 }
 
 template<class TFloat>
@@ -539,7 +537,7 @@ void SUCMP_NM::UnifracVawUnnormalizedWeightedTask<TFloat>::_run(unsigned int fil
 
     // openacc only works well with local variables
     const TFloat * const __restrict__ lengths = this->lengths;
-    const TFloat * const __restrict__ embedded_proportions = this->embedded_proportions;
+    const TFloat * const __restrict__ embedded_proportions = this->get_embedded_proportions();
     const TFloat * const __restrict__ embedded_counts = this->embedded_counts;
     const TFloat * const __restrict__ sample_total_counts = this->sample_total_counts;
     TFloat * const __restrict__ dm_stripes_buf = this->dm_stripes.buf;
@@ -602,10 +600,8 @@ void SUCMP_NM::UnifracVawUnnormalizedWeightedTask<TFloat>::_run(unsigned int fil
       }
     }
 
-#if defined(_OPENACC) || defined(OMPGPU)
    // next iteration will use the alternative space
-   std::swap(this->embedded_proportions,this->embedded_proportions_alt);
-#endif
+   this->set_alt_embedded_proportions();
 }
 
 // Single step in computing NormalizedWeighted Unifrac
@@ -887,7 +883,7 @@ void SUCMP_NM::UnifracNormalizedWeightedTask<TFloat>::_run(unsigned int filled_e
 
     // openacc only works well with local variables
     const TFloat * const __restrict__ lengths = this->lengths;
-    const TFloat * const __restrict__ embedded_proportions = this->embedded_proportions;
+    const TFloat * const __restrict__ embedded_proportions = this->get_embedded_proportions();
     TFloat * const __restrict__ dm_stripes_buf = this->dm_stripes.buf;
     TFloat * const __restrict__ dm_stripes_total_buf = this->dm_stripes_total.buf;
 
@@ -987,10 +983,6 @@ void SUCMP_NM::UnifracNormalizedWeightedTask<TFloat>::_run(unsigned int filled_e
     } // for ss
 #endif
 
-#if defined(_OPENACC) || defined(OMPGPU)
-   // next iteration will use the alternative space
-   std::swap(this->embedded_proportions,this->embedded_proportions_alt);
-#endif
 }
 
 template<class TFloat>
@@ -1002,7 +994,7 @@ void SUCMP_NM::UnifracVawNormalizedWeightedTask<TFloat>::_run(unsigned int fille
 
     // openacc only works well with local variables
     const TFloat * const __restrict__ lengths = this->lengths;
-    const TFloat * const __restrict__ embedded_proportions = this->embedded_proportions;
+    const TFloat * const __restrict__ embedded_proportions = this->get_embedded_proportions();
     const TFloat * const __restrict__ embedded_counts = this->embedded_counts;
     const TFloat * const __restrict__ sample_total_counts = this->sample_total_counts;
     TFloat * const __restrict__ dm_stripes_buf = this->dm_stripes.buf;
@@ -1072,10 +1064,8 @@ void SUCMP_NM::UnifracVawNormalizedWeightedTask<TFloat>::_run(unsigned int fille
       }
     }
 
-#if defined(_OPENACC) || defined(OMPGPU)
    // next iteration will use the alternative space
-   std::swap(this->embedded_proportions,this->embedded_proportions_alt);
-#endif
+   this->set_alt_embedded_proportions();
 }
 
 template<class TFloat>
@@ -1087,7 +1077,7 @@ void SUCMP_NM::UnifracGeneralizedTask<TFloat>::_run(unsigned int filled_embs) {
 
     // openacc only works well with local variables
     const TFloat * const __restrict__ lengths = this->lengths;
-    const TFloat * const __restrict__ embedded_proportions = this->embedded_proportions;
+    const TFloat * const __restrict__ embedded_proportions = this->get_embedded_proportions();
     TFloat * const __restrict__ dm_stripes_buf = this->dm_stripes.buf;
     TFloat * const __restrict__ dm_stripes_total_buf = this->dm_stripes_total.buf;
 
@@ -1155,10 +1145,8 @@ void SUCMP_NM::UnifracGeneralizedTask<TFloat>::_run(unsigned int filled_embs) {
       }
     }
 
-#if defined(_OPENACC) || defined(OMPGPU)
    // next iteration will use the alternative space
-   std::swap(this->embedded_proportions,this->embedded_proportions_alt);
-#endif
+   this->set_alt_embedded_proportions();
 }
 
 template<class TFloat>
@@ -1172,7 +1160,7 @@ void SUCMP_NM::UnifracVawGeneralizedTask<TFloat>::_run(unsigned int filled_embs)
 
     // openacc only works well with local variables
     const TFloat * const __restrict__ lengths = this->lengths;
-    const TFloat * const __restrict__ embedded_proportions = this->embedded_proportions;
+    const TFloat * const __restrict__ embedded_proportions = this->get_embedded_proportions();
     const TFloat * const __restrict__ embedded_counts = this->embedded_counts;
     const TFloat * const __restrict__ sample_total_counts = this->sample_total_counts;
     TFloat * const __restrict__ dm_stripes_buf = this->dm_stripes.buf;
@@ -1245,10 +1233,8 @@ void SUCMP_NM::UnifracVawGeneralizedTask<TFloat>::_run(unsigned int filled_embs)
       }
     }
 
-#if defined(_OPENACC) || defined(OMPGPU)
    // next iteration will use the alternative space
-   std::swap(this->embedded_proportions,this->embedded_proportions_alt);
-#endif
+   this->set_alt_embedded_proportions();
 }
 
 // Single step in computing Unweighted Unifrac
@@ -1576,7 +1562,7 @@ void SUCMP_NM::UnifracUnweightedTask<TFloat>::_run(unsigned int filled_embs) {
 
     // openacc only works well with local variables
     const TFloat * const __restrict__ lengths = this->lengths;
-    const uint64_t * const __restrict__ embedded_proportions = this->embedded_proportions;
+    const uint64_t * const __restrict__ embedded_proportions = this->get_embedded_proportions();
     TFloat * const __restrict__ dm_stripes_buf = this->dm_stripes.buf;
     TFloat * const __restrict__ dm_stripes_total_buf = this->dm_stripes_total.buf;
 
@@ -1731,10 +1717,8 @@ void SUCMP_NM::UnifracUnweightedTask<TFloat>::_run(unsigned int filled_embs) {
     } // for ss
 #endif
 
-#if defined(_OPENACC) || defined(OMPGPU)
    // next iteration will use the alternative space
-   std::swap(this->embedded_proportions,this->embedded_proportions_alt);
-#endif
+   this->set_alt_embedded_proportions();
 }
 
 template<class TFloat>
@@ -1746,7 +1730,7 @@ void SUCMP_NM::UnifracVawUnweightedTask<TFloat>::_run(unsigned int filled_embs) 
 
     // openacc only works well with local variables
     const TFloat * const __restrict__ lengths = this->lengths;
-    const uint32_t * const __restrict__ embedded_proportions = this->embedded_proportions;
+    const uint32_t * const __restrict__ embedded_proportions = this->get_embedded_proportions();
     const TFloat  * const __restrict__ embedded_counts = this->embedded_counts;
     const TFloat  * const __restrict__ sample_total_counts = this->sample_total_counts;
     TFloat * const __restrict__ dm_stripes_buf = this->dm_stripes.buf;
@@ -1833,9 +1817,7 @@ void SUCMP_NM::UnifracVawUnweightedTask<TFloat>::_run(unsigned int filled_embs) 
       }
     }
 
-#if defined(_OPENACC) || defined(OMPGPU)
    // next iteration will use the alternative space
-   std::swap(this->embedded_proportions,this->embedded_proportions_alt);
-#endif
+   this->set_alt_embedded_proportions();
 }
 

--- a/src/unifrac_task.hpp
+++ b/src/unifrac_task.hpp
@@ -89,9 +89,9 @@ namespace SUCMP_NM {
              }
            }
 #if defined(OMPGPU)
-#pragma omp target enter data map(to:ibuf[:bufels])
+#pragma omp target enter data map(to:ibuf[0:bufels])
 #elif defined(_OPENACC)
-#pragma acc enter data copyin(ibuf[:bufels])
+#pragma acc enter data copyin(ibuf[0:bufels])
 #endif    
         }
       }
@@ -108,9 +108,9 @@ namespace SUCMP_NM {
         TFloat* const ibuf = buf;
         if (ibuf != NULL) {
 #if defined(OMPGPU)
-#pragma omp target exit data map(from:ibuf[:bufels])
+#pragma omp target exit data map(from:ibuf[0:bufels])
 #elif defined(_OPENACC)
-#pragma acc exit data copyout(ibuf[:bufels])
+#pragma acc exit data copyout(ibuf[0:bufels])
 #endif
           for(uint64_t stripe=start_idx; stripe < stop_idx; stripe++) {
              double * dm_stripe = dm_stripes[stripe];
@@ -171,11 +171,11 @@ namespace SUCMP_NM {
 #if defined(_OPENACC) || defined(OMPGPU)
           const uint64_t bsize = get_embedded_bsize(dm_stripes.n_samples_r,max_embs);
 #if defined(OMPGPU)
-#pragma omp target exit data map(delete:embedded_proportions_alt[:bsize])
-#pragma omp target exit data map(delete:embedded_proportions[:bsize])
+#pragma omp target exit data map(delete:embedded_proportions_alt[0:bsize])
+#pragma omp target exit data map(delete:embedded_proportions[0:bsize])
 #else
-#pragma acc exit data delete(embedded_proportions_alt[:bsize])
-#pragma acc exit data delete(embedded_proportions[:bsize])
+#pragma acc exit data delete(embedded_proportions_alt[0:bsize])
+#pragma acc exit data delete(embedded_proportions0[0:bsize])
 #endif
 
           free(embedded_proportions_alt);
@@ -189,9 +189,9 @@ namespace SUCMP_NM {
           const uint64_t  n_samples_r = dm_stripes.n_samples_r;
           const uint64_t bsize = n_samples_r * get_emb_els(filled_embs);
 #if defined(OMPGPU)
-#pragma omp target update to(embedded_proportions[:bsize])
+#pragma omp target update to(embedded_proportions[0:bsize])
 #else
-#pragma acc update device(embedded_proportions[:bsize])
+#pragma acc update device(embedded_proportions[0:bsize])
 #endif
 
 #endif
@@ -209,9 +209,9 @@ namespace SUCMP_NM {
 
           TEmb* buf = (TEmb*) malloc(sizeof(TEmb) * bsize);
 #if defined(OMPGPU)
-#pragma omp target enter data map(alloc:buf[:bsize])
+#pragma omp target enter data map(alloc:buf[0:bsize])
 #elif defined(_OPENACC)
-#pragma acc enter data create(buf[:bsize])
+#pragma acc enter data create(buf[0:bsize])
 #endif
           return buf;
         }
@@ -372,9 +372,9 @@ namespace SUCMP_NM {
           zcheck = (bool*) malloc(sizeof(bool) * n_samples);
           sums = (TFloat*) malloc(sizeof(TFloat) * n_samples);
 #if defined(OMPGPU)
-#pragma omp target enter data map(alloc:zcheck[:n_samples],sums[:n_samples])
+#pragma omp target enter data map(alloc:zcheck[0:n_samples],sums[0:n_samples])
 #elif defined(_OPENACC)
-#pragma acc enter data create(zcheck[:n_samples],sums[:n_samples])
+#pragma acc enter data create(zcheck[0:n_samples],sums[0:n_samples])
 #endif
         }
 
@@ -386,9 +386,9 @@ namespace SUCMP_NM {
 #if defined(_OPENACC) || defined(OMPGPU)
           const unsigned int n_samples = this->task_p->n_samples;
 #if defined(OMPGPU)
-#pragma omp target exit data map(delete:sums[:n_samples],zcheck[:n_samples])
+#pragma omp target exit data map(delete:sums[0:n_samples],zcheck[0:n_samples])
 #else
-#pragma acc exit data delete(sums[:n_samples],zcheck[:n_samples])
+#pragma acc exit data delete(sums[0:n_samples],zcheck[0:n_samples])
 #endif
 
 #endif
@@ -417,9 +417,9 @@ namespace SUCMP_NM {
           zcheck = (bool*) malloc(sizeof(bool) * n_samples);
           sums = (TFloat*) malloc(sizeof(TFloat) * n_samples);
 #if defined(OMPGPU)
-#pragma omp target enter data map(alloc:zcheck[:n_samples],sums[:n_samples])
+#pragma omp target enter data map(alloc:zcheck[0:n_samples],sums[0:n_samples])
 #elif defined(_OPENACC)
-#pragma acc enter data create(zcheck[:n_samples],sums[:n_samples])
+#pragma acc enter data create(zcheck[0:n_samples],sums[0:n_samples])
 #endif
         }
 
@@ -431,9 +431,9 @@ namespace SUCMP_NM {
 #if defined(_OPENACC) || defined(OMPGPU)
           const unsigned int n_samples = this->task_p->n_samples;
 #if defined(OMPGPU)
-#pragma omp target exit data map(delete:sums[:n_samples],zcheck[:n_samples])
+#pragma omp target exit data map(delete:sums[0:n_samples],zcheck[0:n_samples])
 #else
-#pragma acc exit data delete(sums[:n_samples],zcheck[:n_samples])
+#pragma acc exit data delete(sums[0:n_samples],zcheck[0:n_samples])
 #endif
 
 #endif
@@ -466,9 +466,9 @@ namespace SUCMP_NM {
           stripe_sums = (TFloat*) malloc(sizeof(TFloat) *  n_samples);
           sums = (TFloat*) malloc(sizeof(TFloat) * bsize);
 #if defined(OMPGPU)
-#pragma omp target enter data map(alloc:zcheck[:n_samples],stripe_sums[:n_samples],sums[:bsize])
+#pragma omp target enter data map(alloc:zcheck[0:n_samples],stripe_sums[0:n_samples],sums[0:bsize])
 #elif defined(_OPENACC)
-#pragma acc enter data create(zcheck[:n_samples],stripe_sums[:n_samples],sums[:bsize])
+#pragma acc enter data create(zcheck[0:n_samples],stripe_sums[0:n_samples],sums[0:bsize])
 #endif
         }
 
@@ -481,9 +481,9 @@ namespace SUCMP_NM {
           const unsigned int n_samples = this->task_p->n_samples;
           const unsigned int bsize = this->max_embs*(0x400/32);
 #if defined(OMPGPU)
-#pragma omp target exit data map(delete:sums[:bsize],stripe_sums[:n_samples],zcheck[:n_samples])
+#pragma omp target exit data map(delete:sums[0:bsize],stripe_sums[0:n_samples],zcheck[0:n_samples])
 #else
-#pragma acc exit data delete(sums[:bsize],stripe_sums[:n_samples],zcheck[:n_samples])
+#pragma acc exit data delete(sums[0:bsize],stripe_sums[0:n_samples],zcheck[0:n_samples])
 #endif
 
 #endif
@@ -586,9 +586,9 @@ namespace SUCMP_NM {
 #if defined(_OPENACC) || defined(OMPGPU)
           const uint64_t bsize = UnifracTaskBase<TFloat,TFloat>::get_embedded_bsize(this->dm_stripes.n_samples_r,this->max_embs);
 #if defined(OMPGPU)
-#pragma omp target exit data map(delete:embedded_counts[:bsize])
+#pragma omp target exit data map(delete:embedded_counts[0:bsize])
 #else
-#pragma acc exit data delete(embedded_counts[:bsize])
+#pragma acc exit data delete(embedded_counts[0:bsize])
 #endif
 
 #endif
@@ -601,9 +601,9 @@ namespace SUCMP_NM {
           const uint64_t  n_samples_r = this->dm_stripes.n_samples_r;
           const uint64_t bsize = n_samples_r * filled_embs;
 #if defined(OMPGPU)
-#pragma omp target update to(embedded_counts[:bsize])
+#pragma omp target update to(embedded_counts[0:bsize])
 #else
-#pragma acc update device(embedded_counts[:bsize])
+#pragma acc update device(embedded_counts[0:bsize])
 #endif
 
 #endif

--- a/src/unifrac_task.hpp
+++ b/src/unifrac_task.hpp
@@ -171,8 +171,8 @@ namespace SUCMP_NM {
 #if defined(_OPENACC) || defined(OMPGPU)
           const uint64_t bsize = get_embedded_bsize(dm_stripes.n_samples_r,max_embs);
 #if defined(OMPGPU)
-#pragma omp target exit data map(release:embedded_proportions_alt[:bsize])
-#pragma omp target exit data map(release:embedded_proportions[:bsize])
+#pragma omp target exit data map(delete:embedded_proportions_alt[:bsize])
+#pragma omp target exit data map(delete:embedded_proportions[:bsize])
 #else
 #pragma acc exit data delete(embedded_proportions_alt[:bsize])
 #pragma acc exit data delete(embedded_proportions[:bsize])
@@ -386,7 +386,7 @@ namespace SUCMP_NM {
 #if defined(_OPENACC) || defined(OMPGPU)
           const unsigned int n_samples = this->task_p->n_samples;
 #if defined(OMPGPU)
-#pragma omp target exit data map(release:sums[:n_samples],zcheck[:n_samples])
+#pragma omp target exit data map(delete:sums[:n_samples],zcheck[:n_samples])
 #else
 #pragma acc exit data delete(sums[:n_samples],zcheck[:n_samples])
 #endif
@@ -431,7 +431,7 @@ namespace SUCMP_NM {
 #if defined(_OPENACC) || defined(OMPGPU)
           const unsigned int n_samples = this->task_p->n_samples;
 #if defined(OMPGPU)
-#pragma omp target exit data map(release:sums[:n_samples],zcheck[:n_samples])
+#pragma omp target exit data map(delete:sums[:n_samples],zcheck[:n_samples])
 #else
 #pragma acc exit data delete(sums[:n_samples],zcheck[:n_samples])
 #endif
@@ -481,7 +481,7 @@ namespace SUCMP_NM {
           const unsigned int n_samples = this->task_p->n_samples;
           const unsigned int bsize = this->max_embs*(0x400/32);
 #if defined(OMPGPU)
-#pragma omp target exit data map(release:sums[:bsize],stripe_sums[:n_samples],zcheck[:n_samples])
+#pragma omp target exit data map(delete:sums[:bsize],stripe_sums[:n_samples],zcheck[:n_samples])
 #else
 #pragma acc exit data delete(sums[:bsize],stripe_sums[:n_samples],zcheck[:n_samples])
 #endif
@@ -586,7 +586,7 @@ namespace SUCMP_NM {
 #if defined(_OPENACC) || defined(OMPGPU)
           const uint64_t bsize = UnifracTaskBase<TFloat,TFloat>::get_embedded_bsize(this->dm_stripes.n_samples_r,this->max_embs);
 #if defined(OMPGPU)
-#pragma omp target exit data map(release:embedded_counts[:bsize])
+#pragma omp target exit data map(delete:embedded_counts[:bsize])
 #else
 #pragma acc exit data delete(embedded_counts[:bsize])
 #endif

--- a/src/unifrac_task.hpp
+++ b/src/unifrac_task.hpp
@@ -212,13 +212,7 @@ namespace SUCMP_NM {
         static TEmb *initialize_embedded(const uint64_t  n_samples_r, unsigned int max_embs) {
           const uint64_t bsize = get_embedded_bsize(n_samples_r, max_embs);
 
-          TEmb* buf = NULL;
-          int err = posix_memalign((void **)&buf, 4096, sizeof(TEmb) * bsize);
-          if(buf == NULL || err != 0) {
-            fprintf(stderr, "Failed to allocate %zd bytes, err %d; [%s]:%d\n",
-                    sizeof(TEmb) * bsize, err, __FILE__, __LINE__);
-             exit(EXIT_FAILURE);
-          }
+          TEmb* buf = (TEmb*) malloc(sizeof(TEmb) * bsize);
 #if defined(OMPGPU)
 #pragma omp target enter data map(alloc:buf[:bsize])
 #elif defined(_OPENACC)
@@ -380,10 +374,8 @@ namespace SUCMP_NM {
         {
           const unsigned int n_samples = this->task_p->n_samples;
 
-          zcheck = NULL;
-          sums = NULL;
-          posix_memalign((void **)&zcheck, 4096, sizeof(bool) * n_samples);
-          posix_memalign((void **)&sums  , 4096, sizeof(TFloat) * n_samples);
+          zcheck = (bool*) malloc(sizeof(bool) * n_samples);
+          sums = (TFloat*) malloc(sizeof(TFloat) * n_samples);
 #if defined(OMPGPU)
 #pragma omp target enter data map(alloc:zcheck[:n_samples],sums[:n_samples])
 #elif defined(_OPENACC)
@@ -427,10 +419,8 @@ namespace SUCMP_NM {
         {
           const unsigned int n_samples = this->task_p->n_samples;
 
-          zcheck = NULL;
-          sums = NULL;
-          posix_memalign((void **)&zcheck, 4096, sizeof(bool) * n_samples);
-          posix_memalign((void **)&sums  , 4096, sizeof(TFloat) * n_samples);
+          zcheck = (bool*) malloc(sizeof(bool) * n_samples);
+          sums = (TFloat*) malloc(sizeof(TFloat) * n_samples);
 #if defined(OMPGPU)
 #pragma omp target enter data map(alloc:zcheck[:n_samples],sums[:n_samples])
 #elif defined(_OPENACC)
@@ -477,12 +467,9 @@ namespace SUCMP_NM {
         {
           const unsigned int n_samples = this->task_p->n_samples;
           const unsigned int bsize = _max_embs*(0x400/32);
-          zcheck = NULL;
-          stripe_sums = NULL;
-          sums = NULL;
-          posix_memalign((void **)&zcheck, 4096, sizeof(bool) * n_samples);
-          posix_memalign((void **)&stripe_sums, 4096, sizeof(TFloat) *  n_samples);
-          posix_memalign((void **)&sums, 4096, sizeof(TFloat) * bsize);
+          zcheck = (bool*) malloc(sizeof(bool) * n_samples);
+          stripe_sums = (TFloat*) malloc(sizeof(TFloat) *  n_samples);
+          sums = (TFloat*) malloc(sizeof(TFloat) * bsize);
 #if defined(OMPGPU)
 #pragma omp target enter data map(alloc:zcheck[:n_samples],stripe_sums[:n_samples],sums[:bsize])
 #elif defined(_OPENACC)


### PR DESCRIPTION
OpenMP Target has more support than OpenACC, so this will make porting to other vendors easier.
We keep OpenACC support for now, as it is still the preferred method for NVIDIA.

Note: Async handling in OpenMP is a little more tricky than in OpenACC, so all OpenMP calls are synchronous for now.

Note2: Also fixed a GPU memory leak which was due to the compiler's inability to properly track reference tracking over complex code.