### PR TITLE
Avoid division by zero

### DIFF
--- a/src/unifrac_internal.cpp
+++ b/src/unifrac_internal.cpp
@@ -185,6 +185,11 @@ void su::set_proportions(TFloat* __restrict__ props,
        if (normalize) {
 #pragma omp parallel for schedule(static)
         for(unsigned int i = 0; i < table.n_samples; i++) {
+            if (sample_counts[i] == 0) {
+                props[i] = props[i] > 0 ?  std::numeric_limits<double>::max() :
+                    std::numeric_limits<double>::lowest();
+                continue;
+            }
            props[i] /= sample_counts[i];
         }
        }

--- a/src/unifrac_internal.cpp
+++ b/src/unifrac_internal.cpp
@@ -186,11 +186,10 @@ void su::set_proportions(TFloat* __restrict__ props,
 #pragma omp parallel for schedule(static)
         for(unsigned int i = 0; i < table.n_samples; i++) {
             if (sample_counts[i] == 0) {
-                props[i] = props[i] > 0 ? std::numeric_limits<double>::max() :
-                    std::numeric_limits<double>::lowest();
+                props[i] = 0;
                 continue;
             }
-           props[i] /= sample_counts[i];
+            props[i] /= sample_counts[i];
         }
        }
 

--- a/src/unifrac_internal.cpp
+++ b/src/unifrac_internal.cpp
@@ -186,7 +186,7 @@ void su::set_proportions(TFloat* __restrict__ props,
 #pragma omp parallel for schedule(static)
         for(unsigned int i = 0; i < table.n_samples; i++) {
             if (sample_counts[i] == 0) {
-                props[i] = props[i] > 0 ?  std::numeric_limits<double>::max() :
+                props[i] = props[i] > 0 ? std::numeric_limits<double>::max() :
                     std::numeric_limits<double>::lowest();
                 continue;
             }


### PR DESCRIPTION
This addresses https://github.com/biocore/unifrac-binaries/issues/51

While it is not addressing the root cause (sample_counts[0] == 0), it allows to avoid undefined behaviour and allows the test to pass.