### PR TITLE
Add dense pair support in the API

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,6 +94,7 @@ jobs:
         popd
         pushd test
         ./capi_test 1
+        ./capi_inmem_test 1
         # explicitly check that we do not have hdf5 dependencies
         if [[ "$(uname -s)" == "Linux" ]];
         then

--- a/combined/libssu.c
+++ b/combined/libssu.c
@@ -156,7 +156,7 @@ void destroy_bptree_opaque(opaque_bptree_t** tree_data) {
 }
 
 IOStatus read_bptree_opaque(const char* tree_filename, opaque_bptree_t** tree_data) {
-   if (dl_read_bptree_opaque==NULL) ssu_load("read_bptree_opaque", (void **) &read_bptree_opaque);
+   if (dl_read_bptree_opaque==NULL) ssu_load("read_bptree_opaque", (void **) &dl_read_bptree_opaque);
 
    return (*dl_read_bptree_opaque)(tree_filename,tree_data);
 }

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -709,6 +709,39 @@ compute_status one_off_matrix_fp32_v2(const char* biom_filename, const char* tre
     return one_off_matrix_v2_T<float,mat_full_fp32_t>(table,tree,unifrac_method,variance_adjust,alpha,bypass_tips,nthreads,subsample_depth,subsample_with_replacement,mmap_dir,result);
 }
 
+/* As above, but from a pre-loaded tree object */
+compute_status one_off_matrix_v2t(const char* biom_filename, const opaque_bptree_t* tree_data,
+                                 const char* unifrac_method, bool variance_adjust, double alpha,
+                                 bool bypass_tips, unsigned int nthreads,
+                                 unsigned int subsample_depth, bool subsample_with_replacement, const char *mmap_dir,
+                                 mat_full_fp64_t** result) {
+    SETUP_TDBG("one_off_matrix_wtree")
+    if (tree_data==NULL) return tree_missing;
+    if (tree_data->opaque==NULL) return tree_missing;
+    CHECK_FILE(biom_filename, table_missing)
+    const su::BPTree &tree = *( (su::BPTree*) tree_data->opaque);
+    su::biom table(biom_filename);
+    VALIDATE_TREE_TABLE(tree, table)
+    TDBG_STEP("load_files")
+    return one_off_matrix_v2_T<double,mat_full_fp64_t>(table,tree,unifrac_method,variance_adjust,alpha,bypass_tips,nthreads,subsample_depth,subsample_with_replacement,mmap_dir,result);
+}
+
+compute_status one_off_matrix_fp32_v2t(const char* biom_filename, const opaque_bptree_t* tree_data,
+                                      const char* unifrac_method, bool variance_adjust, double alpha,
+                                      bool bypass_tips, unsigned int nthreads,
+                                      unsigned int subsample_depth, bool subsample_with_replacement, const char *mmap_dir,
+                                      mat_full_fp32_t** result) {
+    SETUP_TDBG("one_off_matrix_fp32_wtree")
+    if (tree_data==NULL) return tree_missing;
+    if (tree_data->opaque==NULL) return tree_missing;
+    CHECK_FILE(biom_filename, table_missing)
+    const su::BPTree &tree = *( (su::BPTree*) tree_data->opaque);
+    su::biom table(biom_filename);
+    VALIDATE_TREE_TABLE(tree, table)
+    TDBG_STEP("load_files")
+    return one_off_matrix_v2_T<float,mat_full_fp32_t>(table,tree,unifrac_method,variance_adjust,alpha,bypass_tips,nthreads,subsample_depth,subsample_with_replacement,mmap_dir,result);
+}
+
 // Old interface
 compute_status one_off_matrix(const char* biom_filename, const char* tree_filename,
                               const char* unifrac_method, bool variance_adjust, double alpha,

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -123,30 +123,36 @@ inline std::string get_tree_content(const char* tree_filename) {
 }
 
 /* Read tree from file and fill tree_data */
-IOStatus read_bptree_opaque(const char* tree_filename, opaque_bptree_t* tree_data) {
+IOStatus read_bptree_opaque(const char* tree_filename, opaque_bptree_t** tree_data) {
     SETUP_TDBG("read_bptree_opaque")
     if(tree_data==NULL) return unexpected_end;
     CHECK_FILE(tree_filename, open_error)
     TDBG_STEP("load_files")
-    tree_data->opaque = (void*) new su::BPTree(get_tree_content(tree_filename));
+    *tree_data = (opaque_bptree_t*) new su::BPTree(get_tree_content(tree_filename));
     return read_okay;
 }
 
-void load_bptree_opaque(const char* newick, opaque_bptree_t* tree_data) {
+void load_bptree_opaque(const char* newick, opaque_bptree_t** tree_data) {
     SETUP_TDBG("load_bptree_opaque")
-    tree_data->opaque = (void*) new su::BPTree(newick);
+    *tree_data = (opaque_bptree_t*) new su::BPTree(newick);
 }
 
-void destroy_bptree_opaque(opaque_bptree_t* tree_data) {
+void destroy_bptree_opaque(opaque_bptree_t** tree_data) {
 	if (tree_data!=NULL) {
-		if (tree_data->opaque!=NULL) {
-			su::BPTree *tree = (su::BPTree *) tree_data->opaque;
-			tree_data->opaque = NULL;
-			delete tree;
-		}
+		su::BPTree *tree = (su::BPTree *) (*tree_data);
+		*tree_data = NULL;
+		delete tree;
 	}
 }
 
+/* Return number of elements in BPTree, equvalent to n_parens */
+int get_bptree_opaque_els(opaque_bptree_t* tree_data) {
+	if (tree_data!=NULL) {
+		su::BPTree *tree = (su::BPTree *) tree_data;
+		return tree->get_tip_names().size();
+	}
+	return 0; // just to have a reasonable default
+}
 
 void destroy_stripes(vector<double*> &dm_stripes, vector<double*> &dm_stripes_total, unsigned int n_samples,
                      unsigned int stripe_start, unsigned int stripe_stop) {
@@ -596,9 +602,8 @@ compute_status one_off_wtree(const char* biom_filename, const opaque_bptree_t* t
                              bool bypass_tips, unsigned int n_substeps, mat_t** result) {
     SETUP_TDBG("one_off_wtree")
     if (tree_data==NULL) return tree_missing;
-    if (tree_data->opaque==NULL) return tree_missing;
     CHECK_FILE(biom_filename, table_missing)
-    const su::BPTree &tree = *( (su::BPTree*) tree_data->opaque);
+    const su::BPTree &tree = *( (su::BPTree*) tree_data);
     su::biom table(biom_filename);
     VALIDATE_TREE_TABLE(tree, table)
 
@@ -723,9 +728,8 @@ compute_status one_off_matrix_v2t(const char* biom_filename, const opaque_bptree
                                  mat_full_fp64_t** result) {
     SETUP_TDBG("one_off_matrix_wtree")
     if (tree_data==NULL) return tree_missing;
-    if (tree_data->opaque==NULL) return tree_missing;
     CHECK_FILE(biom_filename, table_missing)
-    const su::BPTree &tree = *( (su::BPTree*) tree_data->opaque);
+    const su::BPTree &tree = *( (su::BPTree*) tree_data);
     su::biom table(biom_filename);
     VALIDATE_TREE_TABLE(tree, table)
     TDBG_STEP("load_files")
@@ -739,9 +743,8 @@ compute_status one_off_matrix_fp32_v2t(const char* biom_filename, const opaque_b
                                       mat_full_fp32_t** result) {
     SETUP_TDBG("one_off_matrix_fp32_wtree")
     if (tree_data==NULL) return tree_missing;
-    if (tree_data->opaque==NULL) return tree_missing;
     CHECK_FILE(biom_filename, table_missing)
-    const su::BPTree &tree = *( (su::BPTree*) tree_data->opaque);
+    const su::BPTree &tree = *( (su::BPTree*) tree_data);
     su::biom table(biom_filename);
     VALIDATE_TREE_TABLE(tree, table)
     TDBG_STEP("load_files")

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -122,13 +122,19 @@ inline std::string get_tree_content(const char* tree_filename) {
     return content;
 }
 
-IOStatus load_bptree_opaque(const char* tree_filename, opaque_bptree_t* tree_data) {
-    SETUP_TDBG("load_bptree_opaque")
+/* Read tree from file and fill tree_data */
+IOStatus read_bptree_opaque(const char* tree_filename, opaque_bptree_t* tree_data) {
+    SETUP_TDBG("read_bptree_opaque")
     if(tree_data==NULL) return unexpected_end;
     CHECK_FILE(tree_filename, open_error)
+    TDBG_STEP("load_files")
     tree_data->opaque = (void*) new su::BPTree(get_tree_content(tree_filename));
-    TDBG_STEP("load_bptree_opaque")
     return read_okay;
+}
+
+void load_bptree_opaque(const char* newick, opaque_bptree_t* tree_data) {
+    SETUP_TDBG("load_bptree_opaque")
+    tree_data->opaque = (void*) new su::BPTree(newick);
 }
 
 void destroy_bptree_opaque(opaque_bptree_t* tree_data) {

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -879,7 +879,7 @@ inline compute_status one_dense_pair(unsigned int n_obs, const char ** obs_ids, 
 		                  const su::BPTree &tree,
                                   const char* unifrac_method, bool variance_adjust, double alpha,
                                   bool bypass_tips, double* result) {
-    SETUP_TDBG("one_dense_pair_v2t")
+    SETUP_TDBG("one_dense_pair")
     bool fp64;
     compute_status rc = is_fp64_method(unifrac_method, fp64);
 

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -95,11 +95,8 @@
                                                             return table_and_tree_do_not_overlap;                                \
                                                         }   
 
-#define PARSE_TREE_TABLE(tree_filename, table_filename) std::ifstream ifs(tree_filename);                                        \
-                                                        std::string content = std::string(std::istreambuf_iterator<char>(ifs),   \
-                                                                                          std::istreambuf_iterator<char>());     \
-                                                        su::BPTree tree(content);                                                \
-                                                        su::biom table(biom_filename);                                           \
+#define PARSE_TREE_TABLE(tree_filename, table_filename) su::BPTree tree(get_tree_content(tree_filename)); \
+                                                        su::biom table(biom_filename);                    \
 							VALIDATE_TREE_TABLE(tree, table)
 
 #define PARSE_SYNC_TREE_TABLE(tree_filename, table_filename) PARSE_TREE_TABLE(tree_filename, table_filename) \
@@ -116,6 +113,32 @@ void ssu_set_random_seed(unsigned int new_seed) {
 bool is_file_exists(const char *fileName) {
     std::ifstream infile(fileName);
         return infile.good();
+}
+
+inline std::string get_tree_content(const char* tree_filename) {
+    std::ifstream ifs(tree_filename);
+    std::string content = std::string(std::istreambuf_iterator<char>(ifs),
+                                      std::istreambuf_iterator<char>());
+    return content;
+}
+
+IOStatus load_bptree_opaque(const char* tree_filename, opaque_bptree_t* tree_data) {
+    SETUP_TDBG("load_bptree_opaque")
+    if(tree_data==NULL) return unexpected_end;
+    CHECK_FILE(tree_filename, open_error)
+    tree_data->opaque = (void*) new su::BPTree(get_tree_content(tree_filename));
+    TDBG_STEP("load_bptree_opaque")
+    return read_okay;
+}
+
+void destroy_bptree_opaque(opaque_bptree_t* tree_data) {
+	if (tree_data!=NULL) {
+		if (tree_data->opaque!=NULL) {
+			su::BPTree *tree = (su::BPTree *) tree_data->opaque;
+			tree_data->opaque = NULL;
+			delete tree;
+		}
+	}
 }
 
 
@@ -435,7 +458,7 @@ void set_tasks(std::vector<su::task_parameters> &tasks,
     }
 }
 
-compute_status one_off_inmem_cpp(su::biom_interface &table, su::BPTree &tree,
+compute_status one_off_inmem_cpp(su::biom_interface &table, const su::BPTree &tree,
                              const char* unifrac_method, bool variance_adjust, double alpha,
                              bool bypass_tips, unsigned int nthreads, mat_t** result) {
     SETUP_TDBG("one_off_inmem")
@@ -560,6 +583,22 @@ compute_status one_off(const char* biom_filename, const char* tree_filename,
     TDBG_STEP("load_files")
     // condensed form
     return one_off_inmem_cpp(table, tree, unifrac_method, variance_adjust, alpha, bypass_tips, nthreads, result);
+}
+
+compute_status one_off_wtree(const char* biom_filename, const opaque_bptree_t* tree_data,
+                             const char* unifrac_method, bool variance_adjust, double alpha,
+                             bool bypass_tips, unsigned int n_substeps, mat_t** result) {
+    SETUP_TDBG("one_off_wtree")
+    if (tree_data==NULL) return tree_missing;
+    if (tree_data->opaque==NULL) return tree_missing;
+    CHECK_FILE(biom_filename, table_missing)
+    const su::BPTree &tree = *( (su::BPTree*) tree_data->opaque);
+    su::biom table(biom_filename);
+    VALIDATE_TREE_TABLE(tree, table)
+
+    TDBG_STEP("load_files")
+    // condensed form
+    return one_off_inmem_cpp(table, tree, unifrac_method, variance_adjust, alpha, bypass_tips, n_substeps, result);
 }
 
 // TMat mat_full_fp32_t

--- a/src/api.hpp
+++ b/src/api.hpp
@@ -167,6 +167,16 @@ typedef struct support_bptree {
     int n_parens;
 } support_bptree_t;
 
+/* Opaque BTTree structure for externalizing the full BPTree object
+ * Do not assume anything about the internals of the pointer
+ */
+typedef struct opaque_bptree {
+    void *opaque;
+} opaque_bptree_t;
+
+/* Load from file and fill tree_data */
+EXTERN IOStatus load_bptree_opaque(const char* tree_filename, opaque_bptree_t* tree_data);
+EXTERN void destroy_bptree_opaque(opaque_bptree_t* tree_data);
 
 EXTERN void destroy_mat(mat_t** result);
 EXTERN void destroy_mat_full_fp64(mat_full_fp64_t** result);
@@ -197,6 +207,12 @@ EXTERN void destroy_results_vec(r_vec** result);
 EXTERN ComputeStatus one_off(const char* biom_filename, const char* tree_filename,
                              const char* unifrac_method, bool variance_adjust, double alpha,
                              bool bypass_tips, unsigned int n_substeps, mat_t** result);
+
+
+/* As above, but from a pre-loaded tree object */
+EXTERN ComputeStatus one_off_wtree(const char* biom_filename, const opaque_bptree_t* tree_data,
+                                   const char* unifrac_method, bool variance_adjust, double alpha,
+                                   bool bypass_tips, unsigned int n_substeps, mat_t** result);
 
 
 /* Compute UniFrac - against in-memory objects returning full form matrix

--- a/src/api.hpp
+++ b/src/api.hpp
@@ -305,6 +305,13 @@ EXTERN ComputeStatus one_off_matrix_v2(const char* biom_filename, const char* tr
                                        unsigned int subsample_depth, bool subsample_with_replacement, const char *mmap_dir,
                                        mat_full_fp64_t** result);
 
+/* As above, but from a pre-loaded tree object */
+EXTERN ComputeStatus one_off_matrix_v2t(const char* biom_filename, const opaque_bptree_t* tree_data,
+                                        const char* unifrac_method, bool variance_adjust, double alpha,
+                                        bool bypass_tips, unsigned int n_substeps,
+                                        unsigned int subsample_depth, bool subsample_with_replacement, const char *mmap_dir,
+                                        mat_full_fp64_t** result);
+
 /* Older version, will be deprecated in the future */
 EXTERN ComputeStatus one_off_matrix(const char* biom_filename, const char* tree_filename,
                                     const char* unifrac_method, bool variance_adjust, double alpha,
@@ -339,6 +346,13 @@ EXTERN ComputeStatus one_off_matrix_fp32_v2(const char* biom_filename, const cha
                                             bool bypass_tips, unsigned int n_substeps,
                                             unsigned int subsample_depth, bool subsample_with_replacement, const char *mmap_dir,
                                             mat_full_fp32_t** result);
+
+/* As above, but from a pre-loaded tree object */
+EXTERN ComputeStatus one_off_matrix_fp32_v2t(const char* biom_filename, const opaque_bptree_t* tree_data,
+                                             const char* unifrac_method, bool variance_adjust, double alpha,
+                                             bool bypass_tips, unsigned int n_substeps,
+                                             unsigned int subsample_depth, bool subsample_with_replacement, const char *mmap_dir,
+                                             mat_full_fp32_t** result);
 
 /* Older version, will be deprecated in the future */
 EXTERN ComputeStatus one_off_matrix_fp32(const char* biom_filename, const char* tree_filename,

--- a/src/api.hpp
+++ b/src/api.hpp
@@ -380,6 +380,20 @@ EXTERN ComputeStatus one_off_matrix_fp32(const char* biom_filename, const char* 
 
 /* Compute UniFrac from a pair of dense vectors 
  *
+ * n_obs <unsigned int> the number of observations, corresponding to length of obs_ids, sample1 and sample2
+ * obs_ids <const char**> the observation IDs
+ * sample1 <const double*> sample values
+ * sample2 <const double*> sample values
+ * unifrac_method <const char*> the requested unifrac method.
+ * variance_adjust <bool> whether to apply variance adjustment.
+ * alpha <double> GUniFrac alpha, only relevant if method == generalized.
+ * bypass_tips <bool> disregard tips, reduces compute by about 50%
+ * result <double*> the resulting distance
+ *
+ * one_dense_pair_v2t returns the following error codes:
+ *
+ * okay           : no problems encountered
+ * table_empty    : the table does not have any entries
  */
 EXTERN ComputeStatus one_dense_pair_v2t(unsigned int n_obs, const char ** obs_ids, const double* sample1, const double* sample2,
 		                        const opaque_bptree_t* tree_data,

--- a/src/api.hpp
+++ b/src/api.hpp
@@ -378,6 +378,14 @@ EXTERN ComputeStatus one_off_matrix_fp32(const char* biom_filename, const char* 
                                          const char *mmap_dir,
                                          mat_full_fp32_t** result);
 
+/* Compute UniFrac from a pair of dense vectors 
+ *
+ */
+EXTERN ComputeStatus one_dense_pair_v2t(unsigned int n_obs, const char ** obs_ids, const double* sample1, const double* sample2,
+		                        const opaque_bptree_t* tree_data,
+                                        const char* unifrac_method, bool variance_adjust, double alpha,
+                                        bool bypass_tips, double* result);
+
 /* compute Faith PD
  * biom_filename <const char*> the filename to the biom table.
  * tree_filename <const char*> the filename to the correspodning tree.

--- a/src/api.hpp
+++ b/src/api.hpp
@@ -174,9 +174,11 @@ typedef struct opaque_bptree {
     void *opaque;
 } opaque_bptree_t;
 
-/* Load from file and fill tree_data */
-EXTERN IOStatus load_bptree_opaque(const char* tree_filename, opaque_bptree_t* tree_data);
-EXTERN void destroy_bptree_opaque(opaque_bptree_t* tree_data);
+/* Read tree from file and fill tree_data */
+EXTERN IOStatus read_bptree_opaque(const char* tree_filename, opaque_bptree_t* tree_data);
+
+/* Load tree from newick string and fill tree_data */
+EXTERN void load_bptree_opaque(const char* newick, opaque_bptree_t* tree_data);
 
 EXTERN void destroy_mat(mat_t** result);
 EXTERN void destroy_mat_full_fp64(mat_full_fp64_t** result);
@@ -184,6 +186,8 @@ EXTERN void destroy_mat_full_fp32(mat_full_fp32_t** result);
 EXTERN void destroy_partial_mat(partial_mat_t** result);
 EXTERN void destroy_partial_dyn_mat(partial_dyn_mat_t** result);
 EXTERN void destroy_results_vec(r_vec** result);
+
+EXTERN void destroy_bptree_opaque(opaque_bptree_t* tree_data);
 
 /* Compute UniFrac - condensed form
  *

--- a/src/api.hpp
+++ b/src/api.hpp
@@ -190,6 +190,9 @@ EXTERN IOStatus read_bptree_opaque(const char* tree_filename, opaque_bptree_t** 
 /* Load tree from newick string and fill tree_data */
 EXTERN void load_bptree_opaque(const char* newick, opaque_bptree_t** tree_data);
 
+/* Convert nexplicit tree structure into the opaque form */
+EXTERN void convert_bptree_opaque(const support_bptree_t* in_tree, opaque_bptree_t** tree_data);
+
 EXTERN void destroy_mat(mat_t** result);
 EXTERN void destroy_mat_full_fp64(mat_full_fp64_t** result);
 EXTERN void destroy_mat_full_fp32(mat_full_fp32_t** result);
@@ -399,6 +402,12 @@ EXTERN ComputeStatus one_dense_pair_v2t(unsigned int n_obs, const char ** obs_id
 		                        const opaque_bptree_t* tree_data,
                                         const char* unifrac_method, bool variance_adjust, double alpha,
                                         bool bypass_tips, double* result);
+
+/* Same as above, but usign the explicit treee structure... slightly less efficient */
+EXTERN ComputeStatus one_dense_pair_v2(unsigned int n_obs, const char ** obs_ids, const double* sample1, const double* sample2,
+		                       const support_bptree_t* tree_data,
+                                       const char* unifrac_method, bool variance_adjust, double alpha,
+                                       bool bypass_tips, double* result);
 
 /* compute Faith PD
  * biom_filename <const char*> the filename to the biom table.

--- a/src/api.hpp
+++ b/src/api.hpp
@@ -171,14 +171,24 @@ typedef struct support_bptree {
  * Do not assume anything about the internals of the pointer
  */
 typedef struct opaque_bptree {
-    void *opaque;
+    int dummy;
 } opaque_bptree_t;
 
-/* Read tree from file and fill tree_data */
-EXTERN IOStatus read_bptree_opaque(const char* tree_filename, opaque_bptree_t* tree_data);
+/* Read tree from file and fill tree_data
+ *
+ * tree_filename <const char*> the filename to the correspodning tree.
+ * tree_data <opaque_bptree_t**> the resulting tree data object, this is initialized within the method so using **
+ *
+ * read_bptree_opaque returns the following error codes:
+ *
+ * read_okay      : no problems encountered
+ * open_error     : the filename for the tree does not exist
+ * unexpected_end : any other error.
+ */
+EXTERN IOStatus read_bptree_opaque(const char* tree_filename, opaque_bptree_t** tree_data);
 
 /* Load tree from newick string and fill tree_data */
-EXTERN void load_bptree_opaque(const char* newick, opaque_bptree_t* tree_data);
+EXTERN void load_bptree_opaque(const char* newick, opaque_bptree_t** tree_data);
 
 EXTERN void destroy_mat(mat_t** result);
 EXTERN void destroy_mat_full_fp64(mat_full_fp64_t** result);
@@ -187,7 +197,10 @@ EXTERN void destroy_partial_mat(partial_mat_t** result);
 EXTERN void destroy_partial_dyn_mat(partial_dyn_mat_t** result);
 EXTERN void destroy_results_vec(r_vec** result);
 
-EXTERN void destroy_bptree_opaque(opaque_bptree_t* tree_data);
+EXTERN void destroy_bptree_opaque(opaque_bptree_t** tree_data);
+
+/* Return number of elements in BPTree, equvalent to n_parens */
+EXTERN int get_bptree_opaque_els(opaque_bptree_t* tree_data);
 
 /* Compute UniFrac - condensed form
  *

--- a/src/biom_inmem.cpp
+++ b/src/biom_inmem.cpp
@@ -169,24 +169,24 @@ sparse_data::sparse_data(const uint32_t _n_obs,
 
     if (n_obs>0) {
         malloc_resident();
-	unsigned int start = 0;
+        unsigned int start = 0;
         for (uint32_t i = 0; i < n_obs; i++) {
-	    // pre-allocate with max size
-	    // the waste is stypically acceptable
+            // pre-allocate with max size
+            // the waste is stypically acceptable
             obs_data_resident[i]    = malloc_wcheck<double>(n_samples);
             obs_indices_resident[i] = malloc_wcheck<uint32_t>(n_samples);
 
             unsigned int cnt = 0;
             for (uint32_t j=0; j<n_samples; j++) {
-	      double val = data[j][i];
+              double val = data[j][i];
               if (val>0.0) {
                 obs_data_resident[i][cnt] = val;
-		obs_indices_resident[i][cnt] = j;
-		cnt++;
-	      }
-	    }
+                obs_indices_resident[i][cnt] = j;
+                cnt++;
+              }
+            }
             obs_counts_resident[i]  = cnt;
-	    start+=cnt;
+            start+=cnt;
         }
     }
 }

--- a/src/biom_inmem.cpp
+++ b/src/biom_inmem.cpp
@@ -156,6 +156,41 @@ sparse_data::sparse_data(const uint32_t _n_obs,
     }
 }
 
+// dense to sparse conversion
+sparse_data::sparse_data(const uint32_t _n_obs,
+                         const uint32_t _n_samples,
+                         const double* const *data)
+  : n_obs(_n_obs)
+  , n_samples(_n_samples)
+  , clean_on_destruction(true)
+  , obs_indices_resident(NULL)
+  , obs_data_resident(NULL)
+  , obs_counts_resident(NULL) {
+
+    if (n_obs>0) {
+        malloc_resident();
+	unsigned int start = 0;
+        for (uint32_t i = 0; i < n_obs; i++) {
+	    // pre-allocate with max size
+	    // the waste is stypically acceptable
+            obs_data_resident[i]    = malloc_wcheck<double>(n_samples);
+            obs_indices_resident[i] = malloc_wcheck<uint32_t>(n_samples);
+
+            unsigned int cnt = 0;
+            for (uint32_t j=0; j<n_samples; j++) {
+	      double val = data[j][i];
+              if (val>0.0) {
+                obs_data_resident[i][cnt] = val;
+		obs_indices_resident[i][cnt] = j;
+		cnt++;
+	      }
+	    }
+            obs_counts_resident[i]  = cnt;
+	    start+=cnt;
+        }
+    }
+}
+
 sparse_data::~sparse_data() {
     if(clean_on_destruction) {
         if(obs_indices_resident != NULL && obs_data_resident != NULL) {
@@ -315,6 +350,48 @@ biom_inmem::biom_inmem(const char* const * obs_ids_in,
                        const int _n_samples)
   : biom_interface(_n_samples, _n_obs)
   , resident_obj(_n_obs,_n_samples,indices,indptr,data)
+  , sample_counts(NULL)
+  , obs_id_index()
+  , sample_id_index()
+  , sample_ids()
+  , obs_ids() {
+
+    #pragma omp parallel for schedule(static)
+    for(int x = 0; x < 2; x++) {
+        if(x == 0) {
+            obs_ids.resize(n_obs);
+            for(int i = 0; i < n_obs; i++) {
+                obs_ids[i] = std::string(obs_ids_in[i]);
+            }
+        } else {
+            sample_ids.resize(n_samples);
+            for(int i = 0; i < n_samples; i++) {
+                sample_ids[i] = std::string(samp_ids_in[i]);
+            }
+        }
+    }
+
+    /* define a mapping between an ID and its corresponding offset */
+
+    #pragma omp parallel for schedule(static)
+    for(int i = 0; i < 3; i++) {
+        if(i == 0)
+            create_id_index(obs_ids, obs_id_index);
+        else if(i == 1)
+            create_id_index(sample_ids, sample_id_index);
+        else if(i == 2)
+            compute_sample_counts();
+    }
+
+}
+
+biom_inmem::biom_inmem(const char* const * obs_ids_in,
+                       const char* const * samp_ids_in,
+                       const double* const * data,
+                       const int _n_obs,
+                       const int _n_samples)
+  : biom_interface(_n_samples, _n_obs)
+  , resident_obj(_n_obs,_n_samples,data)
   , sample_counts(NULL)
   , obs_id_index()
   , sample_id_index()

--- a/src/biom_inmem.hpp
+++ b/src/biom_inmem.hpp
@@ -36,6 +36,15 @@ namespace su {
                         uint32_t* indptr,
                         double* data);
 
+            /* constructor from compress sparse data
+             *
+             * @param n_obs number of observations
+             * @param data vector of vectors of observation counts
+             */
+            sparse_data(const uint32_t n_obs,
+                        const uint32_t n_samples,
+                        const double* const * data);
+
             /* default destructor */
             virtual ~sparse_data();
 
@@ -96,6 +105,20 @@ namespace su {
                        uint32_t* index,
                        uint32_t* indptr,
                        double* data,
+                       const int n_obs,
+                       const int n_samples);
+
+            /* constructor from dense data
+             *
+             * @param obs_ids vector of observation identifiers
+             * @param samp_ids vector of sample identifiers
+             * @param data vector of vectors of observation counts
+             * @param n_obs number of observations
+             * @param n_samples number of samples
+             */
+            biom_inmem(const char* const * obs_ids,
+                       const char* const * samp_ids,
+                       const double* const * data,
                        const int n_obs,
                        const int n_samples);
 

--- a/src/test_su.cpp
+++ b/src/test_su.cpp
@@ -5,12 +5,7 @@
 #include "unifrac_internal.hpp"
 #include "test_helper.hpp"
 
-void test_bptree_constructor_simple() {
-    SUITE_START("bptree constructor simple");
-                                //01234567
-                                //11101000
-    su::BPTree tree("(('123:foo; bar':1,b:2)c);");
-
+void test_bptree_simple_result(const su::BPTree &tree) {
     unsigned int exp_nparens = 8;
 
     std::vector<bool> exp_structure;
@@ -58,6 +53,15 @@ void test_bptree_constructor_simple() {
     ASSERT(tree.get_openclose() == exp_openclose);
     ASSERT(tree.lengths == exp_lengths);
     ASSERT(tree.names == exp_names);
+}
+
+void test_bptree_constructor_simple() {
+    SUITE_START("bptree constructor simple");
+                                //01234567
+                                //11101000
+    su::BPTree tree("(('123:foo; bar':1,b:2)c);");
+
+    test_bptree_simple_result(tree);
 
     SUITE_END();
 }
@@ -69,52 +73,29 @@ void test_bptree_constructor_from_existing() {
     su::BPTree existing("(('123:foo; bar':1,b:2)c);");
     su::BPTree tree(existing.get_structure(), existing.lengths, existing.names);
  
-    unsigned int exp_nparens = 8;
-    std::vector<bool> exp_structure;
-    exp_structure.push_back(true);
-    exp_structure.push_back(true);
-    exp_structure.push_back(true);
-    exp_structure.push_back(false);
-    exp_structure.push_back(true);
-    exp_structure.push_back(false);
-    exp_structure.push_back(false);
-    exp_structure.push_back(false);
+    test_bptree_simple_result(tree);
 
-    std::vector<uint32_t> exp_openclose;
-    exp_openclose.push_back(7);
-    exp_openclose.push_back(6);
-    exp_openclose.push_back(3);
-    exp_openclose.push_back(2);
-    exp_openclose.push_back(5);
-    exp_openclose.push_back(4);
-    exp_openclose.push_back(1);
-    exp_openclose.push_back(0);
+    SUITE_END();
+}
 
-    std::vector<std::string> exp_names;
-    exp_names.push_back(std::string());
-    exp_names.push_back(std::string("c"));
-    exp_names.push_back(std::string("123:foo; bar"));
-    exp_names.push_back(std::string());
-    exp_names.push_back(std::string("b"));
-    exp_names.push_back(std::string());
-    exp_names.push_back(std::string());
-    exp_names.push_back(std::string());
+void test_bptree_constructor_inmem() {
+    SUITE_START("bptree constructor inmem");
+                                //01234567
+                                //11101000
+    su::BPTree tree_org("(('123:foo; bar':1,b:2)c);");
+    test_bptree_simple_result(tree_org);
 
-    std::vector<double> exp_lengths;
-    exp_lengths.push_back(0.0);
-    exp_lengths.push_back(0.0);
-    exp_lengths.push_back(1.0);
-    exp_lengths.push_back(0.0);
-    exp_lengths.push_back(2.0);
-    exp_lengths.push_back(0.0);
-    exp_lengths.push_back(0.0);
-    exp_lengths.push_back(0.0);
 
-    ASSERT(tree.nparens == exp_nparens);
-    ASSERT(tree.get_structure() == exp_structure);
-    ASSERT(tree.get_openclose() == exp_openclose);
-    ASSERT(tree.lengths == exp_lengths);
-    ASSERT(tree.names == exp_names);
+    bool t_structure[] = { true, true, true, false, true, false, false, false };
+    double t_lengths[] = { 0, 0, 1, 0, 2, 0, 0, 0 };
+    const char*  t_names[] = { "", "c", "123:foo; bar", "", "b", "", "", "" };
+    const support_bptree_t support_tree = {t_structure, t_lengths, (char**) t_names, 8};
+
+    su::BPTree tree(support_tree.structure,
+                    support_tree.lengths,
+                    support_tree.names,
+                    support_tree.n_parens);
+    test_bptree_simple_result(tree);
 
     SUITE_END();
 }
@@ -503,6 +484,24 @@ void test_biom_constructor_from_sparse() {
     const char* samp_ids[] = {"Sample1", "Sample2", "Sample3", "Sample4", "Sample5", "Sample6"};
 
     su::biom_inmem table(obs_ids, samp_ids, index, indptr, data, 5, 6);
+    _exercise_get_obs_data(table);
+   
+    SUITE_END();
+}
+
+void test_biom_constructor_from_dense() {
+    SUITE_START("biom from dense constructor");
+    double sample1[] = {0, 5, 0, 2, 0};
+    double sample2[] = {0, 1, 0, 1, 1};
+    double sample3[] = {1, 0, 1, 1, 1};
+    double sample4[] = {0, 2, 4, 0, 0};
+    double sample5[] = {0, 3, 0, 0, 0};
+    double sample6[] = {0, 1, 2, 1, 0};
+    const char* obs_ids[] = {"GG_OTU_1", "GG_OTU_2", "GG_OTU_3", "GG_OTU_4", "GG_OTU_5"};
+    const char* samp_ids[] = {"Sample1", "Sample2", "Sample3", "Sample4", "Sample5", "Sample6"};
+
+    double* data_ptrs[] = {sample1,sample2,sample3,sample4,sample5, sample6};
+    su::biom_inmem table(obs_ids, samp_ids, data_ptrs, 5, 6);
     _exercise_get_obs_data(table);
    
     SUITE_END();
@@ -1951,9 +1950,11 @@ int main(int argc, char** argv) {
     test_bptree_shear_deep();
     test_bptree_collapse_simple();
     test_bptree_collapse_edge();
+    test_bptree_constructor_inmem();
 
     test_biom_constructor();
     test_biom_constructor_from_sparse();
+    test_biom_constructor_from_dense();
     test_biom_nullary();
     test_biom_get_obs_data();
     test_biom_filter();

--- a/src/test_su.cpp
+++ b/src/test_su.cpp
@@ -66,6 +66,17 @@ void test_bptree_constructor_simple() {
     SUITE_END();
 }
 
+void test_bptree_constructor_simple_cpp() {
+    SUITE_START("bptree constructor simple cpp");
+                                //01234567
+                                //11101000
+    su::BPTree tree(std::string("(('123:foo; bar':1,b:2)c);"));
+
+    test_bptree_simple_result(tree);
+
+    SUITE_END();
+}
+
 void test_bptree_constructor_from_existing() {
     SUITE_START("bptree constructor from_existing");
                                 //01234567
@@ -1928,6 +1939,7 @@ void test_bptree_constructor_newline_bug() {
 
 int main(int argc, char** argv) {
     test_bptree_constructor_simple();
+    test_bptree_constructor_simple_cpp();
     test_bptree_constructor_newline_bug();
     test_bptree_constructor_from_existing();
     test_bptree_constructor_single_descendent();

--- a/src/tree.cpp
+++ b/src/tree.cpp
@@ -98,7 +98,7 @@ BPTree::BPTree(const bool* input_structure, const double* input_lengths, const c
     index_and_cache();
 }
 
-BPTree BPTree::mask(std::vector<bool> topology_mask, std::vector<double> in_lengths) const {
+BPTree BPTree::mask(const std::vector<bool>& topology_mask, const std::vector<double>& in_lengths) const {
     
     std::vector<bool> new_structure = std::vector<bool>();
     std::vector<double> new_lengths = std::vector<double>();

--- a/src/tree.cpp
+++ b/src/tree.cpp
@@ -98,7 +98,7 @@ BPTree::BPTree(const bool* input_structure, const double* input_lengths, const c
     index_and_cache();
 }
 
-BPTree BPTree::mask(std::vector<bool> topology_mask, std::vector<double> in_lengths) {
+BPTree BPTree::mask(std::vector<bool> topology_mask, std::vector<double> in_lengths) const {
     
     std::vector<bool> new_structure = std::vector<bool>();
     std::vector<double> new_lengths = std::vector<double>();
@@ -130,7 +130,7 @@ BPTree BPTree::mask(std::vector<bool> topology_mask, std::vector<double> in_leng
     return BPTree(new_structure, new_lengths, new_names);
 }
 
-std::unordered_set<std::string> BPTree::get_tip_names() {
+std::unordered_set<std::string> BPTree::get_tip_names() const {
     std::unordered_set<std::string> observed;
 	
     for(unsigned int i = 0; i < this->nparens; i++) {
@@ -142,7 +142,7 @@ std::unordered_set<std::string> BPTree::get_tip_names() {
     return observed;
 }
 
-BPTree BPTree::shear(std::unordered_set<std::string> to_keep) {
+BPTree BPTree::shear(std::unordered_set<std::string> to_keep) const {
     std::vector<bool> shearmask = std::vector<bool>(this->nparens);
     int32_t p;
 
@@ -162,7 +162,7 @@ BPTree BPTree::shear(std::unordered_set<std::string> to_keep) {
     return this->mask(shearmask, this->lengths);
 }
 
-BPTree BPTree::collapse() {
+BPTree BPTree::collapse() const {
     std::vector<bool> collapsemask = std::vector<bool>(this->nparens);
     std::vector<double> new_lengths = std::vector<double>(this->lengths);
 

--- a/src/tree.cpp
+++ b/src/tree.cpp
@@ -1,20 +1,14 @@
 #include "tree.hpp"
 #include <stack>
 #include <algorithm>
+#include <cstring>
 
 using namespace su;
 
 BPTree::BPTree() { }
 
-BPTree::BPTree(std::string newick) {
-    openclose = std::vector<uint32_t>();
-    lengths = std::vector<double>();
-    names = std::vector<std::string>();
-    excess = std::vector<uint32_t>();
-
-    select_0_index = std::vector<uint32_t>();
-    select_1_index = std::vector<uint32_t>();
-    structure = std::vector<bool>();
+template<typename T>
+void BPTree::_init(T newick) {
     structure.reserve(500000);  // a fair sized tree... avoid reallocs, and its not _that_ much waste if this is wrong
 
     // three pass for parse. not ideal, but easier to map from IOW code    
@@ -33,16 +27,39 @@ BPTree::BPTree(std::string newick) {
     index_and_cache();
 }
 
-BPTree::BPTree(std::vector<bool> input_structure, std::vector<double> input_lengths, std::vector<std::string> input_names) {
-    structure = input_structure;
-    lengths = input_lengths;
-    names = input_names;
-    
-    nparens = structure.size();
+BPTree::BPTree(const std::string& newick) 
+	: lengths() 
+	, names() 
+	, nparens(0)
+	, structure()
+	, openclose()
+	, select_0_index()
+	, select_1_index()
+	, excess() {
+   _init<const std::string&>(newick);
+}
 
-    openclose = std::vector<uint32_t>();
-    select_0_index = std::vector<uint32_t>();
-    select_1_index = std::vector<uint32_t>();
+BPTree::BPTree(const char * newick) 
+	: lengths() 
+	, names() 
+	, nparens(0)
+	, structure()
+	, openclose()
+	, select_0_index()
+	, select_1_index()
+	, excess() {
+   _init<const char *>(newick);
+}
+
+BPTree::BPTree(const std::vector<bool>& input_structure, const std::vector<double>& input_lengths, const std::vector<std::string>& input_names) 
+	: lengths(input_lengths) 
+	, names(input_names) 
+	, nparens(input_structure.size())
+	, structure(input_structure)
+	, openclose()
+	, select_0_index()
+	, select_1_index()
+	, excess() {
     openclose.resize(nparens);
     select_0_index.resize(nparens / 2);
     select_1_index.resize(nparens / 2);
@@ -52,16 +69,18 @@ BPTree::BPTree(std::vector<bool> input_structure, std::vector<double> input_leng
     index_and_cache();
 }
 
-BPTree::BPTree(const bool* input_structure, const double* input_lengths, const char* const * input_names, const int n_parens) {
-    structure = std::vector<bool>();
-    lengths = std::vector<double>();
-    names = std::vector<std::string>();
-
+BPTree::BPTree(const bool* input_structure, const double* input_lengths, const char* const * input_names, const int n_parens)
+	: lengths() 
+	, names() 
+	, nparens(n_parens)
+	, structure()
+	, openclose()
+	, select_0_index()
+	, select_1_index()
+	, excess() {
     structure.resize(n_parens);
     lengths.resize(n_parens);
     names.resize(n_parens);
-
-    nparens = n_parens;
 
     //#pragma omp parallel for schedule(static)
     for(int i = 0; i < n_parens; i++) {
@@ -70,9 +89,6 @@ BPTree::BPTree(const bool* input_structure, const double* input_lengths, const c
         names[i] = std::string(input_names[i]);
     }
 
-    openclose = std::vector<uint32_t>();
-    select_0_index = std::vector<uint32_t>();
-    select_1_index = std::vector<uint32_t>();
     openclose.resize(nparens);
     select_0_index.resize(nparens / 2);
     select_1_index.resize(nparens / 2);
@@ -296,24 +312,25 @@ int32_t BPTree::bwd(uint32_t i, int d) const {
     return -1;
 }
 
-void BPTree::newick_to_bp(std::string newick) {
+void BPTree::newick_to_bp(const char *newick) {
     char last_structure;
     bool potential_single_descendent = false;
     int count = 0;
     bool in_quote = false;
-    for(auto c = newick.begin(); c != newick.end(); c++) {
-        if(*c == '\'') 
+    for(const char* cptr = newick; cptr[0] != 0; cptr++) {
+	 const char c = cptr[0];
+        if(c == '\'') 
             in_quote = !in_quote;
 
         if(in_quote)
             continue;
 
-        switch(*c) {
+        switch(c) {
             case '(':
                 // opening of a node
                 count++;
                 structure.push_back(true);
-                last_structure = *c;
+                last_structure = c;
                 potential_single_descendent = true;
                 break;
             case ')':
@@ -331,7 +348,7 @@ void BPTree::newick_to_bp(std::string newick) {
                     count += 1;
                     structure.push_back(false);
                 }
-                last_structure = *c;
+                last_structure = c;
                 break;
             case ',':
                 if(last_structure != ')') {
@@ -341,7 +358,7 @@ void BPTree::newick_to_bp(std::string newick) {
                     structure.push_back(false);
                 }
                 potential_single_descendent = false;
-                last_structure = *c;
+                last_structure = c;
                 break;
             default:
                 break;
@@ -350,6 +367,9 @@ void BPTree::newick_to_bp(std::string newick) {
     nparens = structure.size();
 }
 
+void BPTree::newick_to_bp(const std::string& newick) {
+	newick_to_bp(newick.c_str());
+}
 
 void BPTree::structure_to_openclose() {
     std::stack<unsigned int> oc;
@@ -367,21 +387,15 @@ void BPTree::structure_to_openclose() {
         }
     }
 }
-// trim from end
-// from http://stackoverflow.com/a/217605
-static inline void rtrim(std::string &s) {
-    s.erase(std::find_if(s.rbegin(), s.rend(), [](unsigned char ch) {
-        return !std::isspace(ch);
-    }).base(), s.end());
-}
 
 //// WEIRDNESS. THIS SOLVES IT WITH THE RTRIM. ISOLATE, MOVE TO CONSTRUCTOR.
-void BPTree::newick_to_metadata(std::string newick) {
-    rtrim(newick);
-    
-    std::string::iterator start = newick.begin();
-    std::string::iterator end = newick.end();
-    std::string token;
+void BPTree::newick_to_metadata(const char*  newick) {
+    const char* start = newick;
+    const char* end = start+strlen(newick);
+    //rtrim i.e.
+    // trim from end
+    while ((end!=start) && std::isspace(end[-1])) end--;
+
     char last_structure = '\0';
 
     unsigned int structure_idx = 0;
@@ -389,7 +403,7 @@ void BPTree::newick_to_metadata(std::string newick) {
     unsigned int open_idx;
 
     while(start != end) {
-        token = tokenize(start, end);
+        std::string token = tokenize(start, end);
         // this sucks. 
         if(token.length() == 1 && is_structure_character(token[0])) {
             switch(token[0]) {
@@ -424,6 +438,10 @@ void BPTree::newick_to_metadata(std::string newick) {
     }
 }
 
+void BPTree::newick_to_metadata(const std::string& newick) {
+	newick_to_metadata(newick.c_str());
+}
+
 void BPTree::set_node_metadata(unsigned int open_idx, std::string &token) {
     double length = 0.0;
     std::string name = std::string();
@@ -441,18 +459,17 @@ void BPTree::set_node_metadata(unsigned int open_idx, std::string &token) {
     lengths[open_idx] = length;
 }
 
-inline bool BPTree::is_structure_character(char c) const {
+inline bool BPTree::is_structure_character(char c) {
     return (c == '(' || c == ')' || c == ',' || c == ';');
 }
 
-std::string BPTree::tokenize(std::string::iterator &start, const std::string::iterator &end) {
+inline std::string BPTree::tokenize(const char * &start, const char * const end) {
     bool inquote = false;
     bool isquote = false;
-    char c;
     std::string token;
     
     do {
-        c = *start;
+        char c = *start;
         start++;
         
         if(c == '\n') {
@@ -483,11 +500,11 @@ std::string BPTree::tokenize(std::string::iterator &start, const std::string::it
     return token;
 }   
 
-std::vector<bool> BPTree::get_structure() {
+const std::vector<bool>& BPTree::get_structure() const {
     return structure;
 }
 
-std::vector<uint32_t> BPTree::get_openclose() {
+const std::vector<uint32_t>& BPTree::get_openclose() const {
     return openclose;
 }
 

--- a/src/tree.hpp
+++ b/src/tree.hpp
@@ -104,7 +104,7 @@ namespace su {
             int32_t parent(uint32_t i) const;
 
             /* get the names at the tips of the tree */
-            std::unordered_set<std::string> get_tip_names();
+            std::unordered_set<std::string> get_tip_names() const;
 
             /* public getters */
             const std::vector<bool>& get_structure() const;
@@ -120,11 +120,11 @@ namespace su {
                 }
                 std::cout << std::endl;
             }
-            BPTree mask(std::vector<bool> topology_mask, std::vector<double> in_lengths); // mask self
+            BPTree mask(std::vector<bool> topology_mask, std::vector<double> in_lengths) const; // mask self
 
-            BPTree shear(std::unordered_set<std::string> to_keep);
+            BPTree shear(std::unordered_set<std::string> to_keep) const;
 
-            BPTree collapse();
+            BPTree collapse() const;
 
         private:
             std::vector<bool> structure;          // the topology

--- a/src/tree.hpp
+++ b/src/tree.hpp
@@ -120,7 +120,7 @@ namespace su {
                 }
                 std::cout << std::endl;
             }
-            BPTree mask(std::vector<bool> topology_mask, std::vector<double> in_lengths) const; // mask self
+            BPTree mask(const std::vector<bool>& topology_mask, const std::vector<double>& in_lengths) const; // mask self
 
             BPTree shear(std::unordered_set<std::string> to_keep) const;
 

--- a/src/tree.hpp
+++ b/src/tree.hpp
@@ -34,7 +34,8 @@ namespace su {
              *
              * @param newick A newick string
              */
-            BPTree(std::string newick);
+            BPTree(const std::string& newick);
+            BPTree(const char * newick);
             
             /* constructor from a defined topology 
              *
@@ -42,7 +43,7 @@ namespace su {
              * @param input_lengths A vector of double of the branch lengths
              * @param input_names A vector of str of the vertex names
              */
-            BPTree(std::vector<bool> input_structure, std::vector<double> input_lengths, std::vector<std::string> input_names);
+            BPTree(const std::vector<bool>& input_structure, const std::vector<double>& input_lengths, const std::vector<std::string>& input_names);
             ~BPTree();
 
             /* constructor from a defined topology using c-types
@@ -106,8 +107,8 @@ namespace su {
             std::unordered_set<std::string> get_tip_names();
 
             /* public getters */
-            std::vector<bool> get_structure();
-            std::vector<uint32_t> get_openclose();
+            const std::vector<bool>& get_structure() const;
+            const std::vector<uint32_t>& get_openclose() const;
 
             /* serialize the structure as a sequence of 1s and 0s */
             void print() {
@@ -133,17 +134,22 @@ namespace su {
             std::vector<uint32_t> excess;
 
             void index_and_cache();  // construct the select caches
-            void newick_to_bp(std::string newick);  // convert a newick string to parentheses
-            void newick_to_metadata(std::string newick);  // convert newick to attributes
+            void newick_to_bp(const char* newick);  // convert a newick string to parentheses
+            void newick_to_bp(const std::string& newick);  // convert a newick string to parentheses
+            void newick_to_metadata(const char* newick);  // convert newick to attributes
+            void newick_to_metadata(const std::string& newick);  // convert newick to attributes
             void structure_to_openclose();  // set the cache mapping between parentheses pairs
             void set_node_metadata(unsigned int open_idx, std::string &token); // set attributes for a node
-            bool is_structure_character(char c) const;  // test if a character is a newick structure
+            static bool is_structure_character(char c);  // test if a character is a newick structure
             inline uint32_t open(uint32_t i) const;  // obtain the index of the opening for a given parenthesis
             inline uint32_t close(uint32_t i) const;  // obtain the index of the closing for a given parenthesis
-            std::string tokenize(std::string::iterator &start, const std::string::iterator &end);  // newick -> tokens
+            static std::string tokenize(const char * &start, const char * const end);  // newick -> tokens
 
             int32_t bwd(uint32_t i, int32_t d) const;
             int32_t enclose(uint32_t i) const;
+
+	    // to be used in the constructors only
+            template<typename T> void _init(T newick);
     };
 }
 

--- a/src/unifrac.cpp
+++ b/src/unifrac.cpp
@@ -43,7 +43,7 @@
 
 using namespace su;
 
-std::string su::test_table_ids_are_subset_of_tree(su::biom_interface &table, su::BPTree &tree) {
+std::string su::test_table_ids_are_subset_of_tree(const su::biom_interface &table, const su::BPTree &tree) {
     std::unordered_set<std::string> tip_names = tree.get_tip_names();
     std::unordered_set<std::string>::const_iterator hit;
     std::string a_missing_name = "";

--- a/src/unifrac.hpp
+++ b/src/unifrac.hpp
@@ -23,7 +23,7 @@
 
         void faith_pd(biom_interface &table, BPTree &tree, double* result);
 
-        std::string test_table_ids_are_subset_of_tree(biom_interface &table, BPTree &tree);
+        std::string test_table_ids_are_subset_of_tree(const biom_interface &table, const BPTree &tree);
         void unifrac(biom_interface &table, 
                      BPTree &tree, 
                      Method unifrac_method,

--- a/test/Makefile
+++ b/test/Makefile
@@ -7,14 +7,18 @@ ifeq ($(PREFIX),)
 	PREFIX := $(CONDA_PREFIX)
 endif
 
-test: capi_test
+test: capi_test capi_inmem_test
 	./capi_test 1
+	./capi_inmem_test 1
 
-test_binaries: capi_test
+test_binaries: capi_test capi_inmem_test
 
 capi_test: capi_test.c
 	$(CC) $(CFLAGS) -std=c99 -O0 -g capi_test.c -I../src -lssu -L${PREFIX}/lib -Wl,-rpath,${PREFIX}/lib $(LDFLAGS) -o capi_test
 
+capi_inmem_test: capi_inmem_test.c
+	$(CC) $(CFLAGS) -std=c99 -O0 -g capi_inmem_test.c -I../src -lssu -L${PREFIX}/lib -Wl,-rpath,${PREFIX}/lib $(LDFLAGS) -o capi_inmem_test
+
 clean:
-	-rm -f *.o capi_test
+	-rm -f *.o capi_test capi_inmem_test
 

--- a/test/capi_inmem_test.c
+++ b/test/capi_inmem_test.c
@@ -91,6 +91,8 @@ void test_su_dense(int num_cores){
 void test_su_matrix(int num_cores){
     mat_full_fp64_t* result = NULL;
     mat_full_fp32_t* result_fp32 = NULL;
+    mat_full_fp64_t* result2 = NULL;
+    mat_full_fp32_t* result2_fp32 = NULL;
     const support_biom_t table = {(char**) obs_ids, (char**) samp_ids, (uint32_t*) indices, (uint32_t*) indptr, (double*) data, n_obs, n_samp, 0};
     const support_bptree_t tree = {(bool*) structure, (double*) lengths, (char**) names, nparens};
 
@@ -134,6 +136,38 @@ void test_su_matrix(int num_cores){
 
 
     destroy_mat_full_fp32(&result_fp32);
+
+    // exercise the old interface, too
+    status = one_off_inmem(&table, &tree, "unweighted_fp64",
+                                  false, 1.0, false, num_cores,
+				  &result2);
+
+    err(status != okay, "Compute failed");
+    err(result2 == NULL, "Empty result");
+    err(result2->n_samples != 6, "Wrong number of samples");
+
+    for(unsigned int i = 0; i < (result2->n_samples*result2->n_samples); i++) {
+        err(fabs(exp[i] - result2->matrix[i]) > 0.00001, "Result is wrong");
+    }
+
+
+    destroy_mat_full_fp64(&result2);
+
+    status = one_off_inmem_fp32(&table, &tree, "unweighted_fp32",
+                                    false, 1.0, false, num_cores,
+				    &result2_fp32);
+
+    err(status != okay, "Compute failed");
+    err(result2 == NULL, "Empty result");
+    err(result2_fp32->n_samples != 6, "Wrong number of samples");
+
+    for(unsigned int i = 0; i < (result2_fp32->n_samples*result2_fp32->n_samples); i++) {
+        err(fabs(exp[i] - result2_fp32->matrix[i]) > 0.00001, "Result is wrong");
+    }
+
+
+    destroy_mat_full_fp32(&result2_fp32);
+
 }
 
 

--- a/test/capi_inmem_test.c
+++ b/test/capi_inmem_test.c
@@ -1,0 +1,150 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdbool.h>
+#include <math.h>
+#include "api.hpp"
+
+#ifndef bool
+#define bool char
+#define true 1
+#define false 0
+#endif
+
+void err(bool condition, const char* msg) {
+    if(condition) {
+        fprintf(stderr, "%s\n", msg);
+        exit(1);
+    }
+} 
+
+// biom
+const unsigned int n_obs = 5;
+const unsigned int n_samp = 6;
+const char* const obs_ids[] = {"GG_OTU_1", "GG_OTU_2", "GG_OTU_3", "GG_OTU_4", "GG_OTU_5"};
+const char* const samp_ids[] = {"Sample1", "Sample2", "Sample3", "Sample4", "Sample5", "Sample6"};
+const uint32_t    indices[] = {2, 0, 1, 3, 4, 5, 2, 3, 5, 0, 1, 2, 5, 1, 2};
+const uint32_t    indptr[] = {0,  1,  6,  9, 13, 15};
+const double      data[]= {1., 5., 1., 2., 3., 1., 1., 4., 2., 2., 1., 1., 1., 1., 1.};
+
+// tree
+const unsigned int nparens = 16;
+const double lengths[] = { 0, 0, 0, 0,
+	                   0, 0, 0, 0,
+	                   0, 0, 0, 0,
+	                   0, 0, 0, 0 };
+const bool structure[] = { true, true, false, true,
+	                   true, false, true, false,
+			   false, true, true, false,
+			   true, false, false, false };
+const char * const names[] = {"", "GG_OTU_1", "", "",
+                              "GG_OTU_2", "", "GG_OTU_3", "",
+			      "", "", "GG_OTU_5", "",
+			      "GG_OTU_4", "", "", ""};
+
+void test_su_dense(int num_cores){
+    double result = 0.0;
+    const support_bptree_t tree = {(bool*) structure, (double*) lengths, (char**) names, nparens};
+    const char* table_oids[] = { "GG_OTU_1", "GG_OTU_2", "GG_OTU_3", "GG_OTU_4", "GG_OTU_5" };
+    const double sample1[] = { 0, 5, 0, 2, 0 };
+    const double sample2[] = { 0, 1, 0, 1, 1 };
+    const double sample3[] = { 1, 0, 1, 1, 1 };
+    const char* method = "unweighted";
+    float exp13 = 0.57142857;
+    float exp21 = 0.2;
+    
+    opaque_bptree_t *tree_data;
+    convert_bptree_opaque(&tree, &tree_data);
+
+    ComputeStatus status;
+    status = one_dense_pair_v2t(5, table_oids, sample1, sample3,
+	                        tree_data, method,
+                                false, 1.0, false,
+				&result);
+
+    err(status != okay, "Compute failed");
+
+    err(fabs(exp13 - result) > 0.00001, "Result is wrong");
+
+    status = one_dense_pair_v2t(5, table_oids, sample2, sample1,
+	                        tree_data, method,
+                                false, 1.0, false,
+				&result);
+
+    err(status != okay, "Compute failed");
+
+    err(fabs(exp21 - result) > 0.00001, "Result is wrong");
+
+    destroy_bptree_opaque(&tree_data);
+
+    // check direct, expanded tree structure, too
+    status = one_dense_pair_v2(5, table_oids, sample1, sample3,
+	                       &tree, method,
+                               false, 1.0, false,
+			       &result);
+
+    err(status != okay, "Compute failed");
+
+    err(fabs(exp13 - result) > 0.00001, "Result is wrong");
+
+}
+
+void test_su_matrix(int num_cores){
+    mat_full_fp64_t* result = NULL;
+    mat_full_fp32_t* result_fp32 = NULL;
+    const support_biom_t table = {(char**) obs_ids, (char**) samp_ids, (uint32_t*) indices, (uint32_t*) indptr, (double*) data, n_obs, n_samp, 0};
+    const support_bptree_t tree = {(bool*) structure, (double*) lengths, (char**) names, nparens};
+
+    float exp[] = { 0.0,        0.2,        0.57142857, 0.6,        0.5,        0.2, 
+                    0.2,        0.0,        0.42857143, 0.66666667, 0.6,        0.33333333,
+		    0.57142857, 0.42857143, 0.0,        0.71428571, 0.85714286, 0.42857143, 
+		    0.6,        0.66666667, 0.71428571, 0.0,        0.33333333, 0.4,
+		    0.5,        0.6,        0.85714286, 0.33333333, 0.0,        0.6,
+                    0.2,        0.33333333, 0.42857143, 0.4,        0.6,        0.0        };
+    
+    ComputeStatus status;
+
+    status = one_off_matrix_inmem_v2(&table, &tree, "unweighted_fp64",
+                                    false, 1.0, false, num_cores,
+                                    0, true, NULL,
+				    &result);
+
+    err(status != okay, "Compute failed");
+    err(result == NULL, "Empty result");
+    err(result->n_samples != 6, "Wrong number of samples");
+
+    for(unsigned int i = 0; i < (result->n_samples*result->n_samples); i++) {
+        err(fabs(exp[i] - result->matrix[i]) > 0.00001, "Result is wrong");
+    }
+
+
+    destroy_mat_full_fp64(&result);
+
+    status = one_off_matrix_inmem_fp32_v2(&table, &tree, "unweighted_fp32",
+                                    false, 1.0, false, num_cores,
+                                    0, true, NULL,
+				    &result_fp32);
+
+    err(status != okay, "Compute failed");
+    err(result == NULL, "Empty result");
+    err(result_fp32->n_samples != 6, "Wrong number of samples");
+
+    for(unsigned int i = 0; i < (result_fp32->n_samples*result_fp32->n_samples); i++) {
+        err(fabs(exp[i] - result_fp32->matrix[i]) > 0.00001, "Result is wrong");
+    }
+
+
+    destroy_mat_full_fp32(&result_fp32);
+}
+
+
+int main(int argc, char** argv) {
+    int num_cores = strtol(argv[1], NULL, 10);
+
+    printf("Testing Striped UniFrac one_dense_pair...\n");
+    test_su_dense(num_cores);
+    printf("Testing Striped UniFrac one_off matrix...\n");
+    test_su_matrix(num_cores);
+    printf("Tests passed.\n");
+    return 0;
+}
+

--- a/test/capi_test.c
+++ b/test/capi_test.c
@@ -39,6 +39,100 @@ void test_su(int num_cores){
 
 }
 
+void test_su_wtree(int num_cores){
+    mat_t* result = NULL;
+    const char* table = "test.biom";
+    const char* tree = "test.tre";
+    const char* method = "unweighted";
+    double exp[] = {0.2, 0.57142857, 0.6, 0.5, 0.2, 0.42857143, 0.66666667, 0.6, 0.33333333, 0.71428571, 0.85714286, 0.42857143, 0.33333333, 0.4, 0.6};
+    
+    opaque_bptree_t tree_data;
+    IOStatus iostatus;
+    iostatus = load_bptree_opaque(tree, &tree_data);
+    err(iostatus != read_okay, "Tree read failed");
+
+
+    ComputeStatus status;
+    status = one_off_wtree(table, &tree_data, method,
+                     false, 1.0, false, num_cores, &result);
+
+    err(status != okay, "Compute failed");
+    err(result == NULL, "Empty result");
+    err(result->n_samples != 6, "Wrong number of samples");
+    err(result->cf_size != 15, "Wrong condensed form size");
+    err(!result->is_upper_triangle, "Result is not squaure");
+
+    for(unsigned int i = 0; i < result->cf_size; i++) 
+        err(fabs(exp[i] - result->condensed_form[i]) > 0.00001, "Result is wrong");
+
+    destroy_bptree_opaque(&tree_data);
+}
+
+void test_su_matrix(int num_cores){
+    mat_full_fp32_t* result = NULL;
+    const char* table = "test.biom";
+    const char* tree = "test.tre";
+    const char* method = "unweighted_fp32";
+    float exp[] = { 0.0,        0.2,        0.57142857, 0.6,        0.5,        0.2, 
+                    0.2,        0.0,        0.42857143, 0.66666667, 0.6,        0.33333333,
+		    0.57142857, 0.42857143, 0.0,        0.71428571, 0.85714286, 0.42857143, 
+		    0.6,        0.66666667, 0.71428571, 0.0,        0.33333333, 0.4,
+		    0.5,        0.6,        0.85714286, 0.33333333, 0.0,        0.6,
+                    0.2,        0.33333333, 0.42857143, 0.4,        0.6,        0.0        };
+    
+    ComputeStatus status;
+    status = one_off_matrix_fp32_v2(table, tree, method,
+                                    false, 1.0, false, num_cores,
+                                    0, true, NULL,
+				    &result);
+
+    err(status != okay, "Compute failed");
+    err(result == NULL, "Empty result");
+    err(result->n_samples != 6, "Wrong number of samples");
+
+    for(unsigned int i = 0; i < (result->n_samples*result->n_samples); i++) {
+        err(fabs(exp[i] - result->matrix[i]) > 0.00001, "Result is wrong");
+    }
+
+
+    destroy_mat_full_fp32(&result);
+}
+
+void test_su_matrix_wtree(int num_cores){
+    mat_full_fp32_t* result = NULL;
+    const char* table = "test.biom";
+    const char* tree = "test.tre";
+    const char* method = "unweighted";
+    float exp[] = { 0.0,        0.2,        0.57142857, 0.6,        0.5,        0.2, 
+                    0.2,        0.0,        0.42857143, 0.66666667, 0.6,        0.33333333,
+		    0.57142857, 0.42857143, 0.0,        0.71428571, 0.85714286, 0.42857143, 
+		    0.6,        0.66666667, 0.71428571, 0.0,        0.33333333, 0.4,
+		    0.5,        0.6,        0.85714286, 0.33333333, 0.0,        0.6,
+                    0.2,        0.33333333, 0.42857143, 0.4,        0.6,        0.0        };
+    
+    opaque_bptree_t tree_data;
+    IOStatus iostatus;
+    iostatus = load_bptree_opaque(tree, &tree_data);
+    err(iostatus != read_okay, "Tree read failed");
+
+    ComputeStatus status;
+    status = one_off_matrix_fp32_v2t(table, &tree_data, method,
+                                    false, 1.0, false, num_cores,
+                                    0, true, NULL,
+				    &result);
+
+    err(status != okay, "Compute failed");
+    err(result == NULL, "Empty result");
+    err(result->n_samples != 6, "Wrong number of samples");
+
+    for(unsigned int i = 0; i < (result->n_samples*result->n_samples); i++) 
+        err(fabs(exp[i] - result->matrix[i]) > 0.00001, "Result is wrong");
+
+
+    destroy_mat_full_fp32(&result);
+    destroy_bptree_opaque(&tree_data);
+}
+
 void test_faith_pd(){
     r_vec* result = NULL;
     const char* table = "test.biom";
@@ -60,8 +154,14 @@ void test_faith_pd(){
 int main(int argc, char** argv) {
     int num_cores = strtol(argv[1], NULL, 10);
 
-    printf("Testing Striped UniFrac...\n");
+    printf("Testing Striped UniFrac one_off...\n");
     test_su(num_cores);
+    printf("Testing Striped UniFrac one_off_wtree...\n");
+    test_su_wtree(num_cores);
+    printf("Testing Striped UniFrac one_off matrix...\n");
+    test_su_matrix(num_cores);
+    printf("Testing Striped UniFrac one_off matrix_wtree...\n");
+    test_su_matrix_wtree(num_cores);
     printf("Tests passed.\n");
     printf("Testing Faith's PD...\n");
     test_faith_pd();

--- a/test/capi_test.c
+++ b/test/capi_test.c
@@ -195,6 +195,31 @@ void test_su_matrix_wtree2(int num_cores){
     destroy_bptree_opaque(&tree_data);
 }
 
+void test_su_dense(int num_cores){
+    double result = 0.0;
+    const char tree_str[] = "(GG_OTU_1:1,(GG_OTU_2:1,GG_OTU_3:1):1,(GG_OTU_5:1,GG_OTU_4:1):1);";
+    const char* table_oids[] = { "GG_OTU_1", "GG_OTU_2", "GG_OTU_3", "GG_OTU_4", "GG_OTU_5" };
+    const double sample1[] = { 0, 5, 0, 2, 0 };
+    const double sample3[] = { 1, 0, 1, 1, 1 };
+    const char* method = "unweighted";
+    float exp13 = 0.57142857;
+    
+    opaque_bptree_t *tree_data;
+    load_bptree_opaque(tree_str, &tree_data);
+
+    ComputeStatus status;
+    status = one_dense_pair_v2t(5, table_oids, sample1, sample3,
+	                        tree_data, method,
+                                false, 1.0, false,
+				&result);
+
+    err(status != okay, "Compute failed");
+
+    err(fabs(exp13 - result) > 0.00001, "Result is wrong");
+
+    destroy_bptree_opaque(&tree_data);
+}
+
 void test_faith_pd(){
     r_vec* result = NULL;
     const char* table = "test.biom";
@@ -226,6 +251,8 @@ int main(int argc, char** argv) {
     printf("Testing Striped UniFrac one_off matrix_wtree...\n");
     test_su_matrix_wtree(num_cores);
     test_su_matrix_wtree2(num_cores);
+    printf("Testing Striped UniFrac one_dense_pair...\n");
+    test_su_dense(num_cores);
     printf("Tests passed.\n");
     printf("Testing Faith's PD...\n");
     test_faith_pd();

--- a/test/capi_test.c
+++ b/test/capi_test.c
@@ -46,14 +46,15 @@ void test_su_wtree(int num_cores){
     const char* method = "unweighted";
     const double exp[] = {0.2, 0.57142857, 0.6, 0.5, 0.2, 0.42857143, 0.66666667, 0.6, 0.33333333, 0.71428571, 0.85714286, 0.42857143, 0.33333333, 0.4, 0.6};
     
-    opaque_bptree_t tree_data;
+    opaque_bptree_t *tree_data;
     IOStatus iostatus;
     iostatus = read_bptree_opaque(tree, &tree_data);
     err(iostatus != read_okay, "Tree read failed");
-
+    int tree_obs = get_bptree_opaque_els(tree_data);
+    err(tree_obs != 5, "Wrong number of obs");
 
     ComputeStatus status;
-    status = one_off_wtree(table, &tree_data, method,
+    status = one_off_wtree(table, tree_data, method,
                      false, 1.0, false, num_cores, &result);
 
     err(status != okay, "Compute failed");
@@ -75,11 +76,13 @@ void test_su_wtree2(int num_cores){
     const char* method = "unweighted";
     const double exp[] = {0.2, 0.57142857, 0.6, 0.5, 0.2, 0.42857143, 0.66666667, 0.6, 0.33333333, 0.71428571, 0.85714286, 0.42857143, 0.33333333, 0.4, 0.6};
     
-    opaque_bptree_t tree_data;
+    opaque_bptree_t *tree_data;
     load_bptree_opaque(tree_str, &tree_data);
+    int tree_obs = get_bptree_opaque_els(tree_data);
+    err(tree_obs != 5, "Wrong number of obs");
 
     ComputeStatus status;
-    status = one_off_wtree(table, &tree_data, method,
+    status = one_off_wtree(table, tree_data, method,
                      false, 1.0, false, num_cores, &result);
 
     err(status != okay, "Compute failed");
@@ -136,13 +139,13 @@ void test_su_matrix_wtree(int num_cores){
 		    0.5,        0.6,        0.85714286, 0.33333333, 0.0,        0.6,
                     0.2,        0.33333333, 0.42857143, 0.4,        0.6,        0.0        };
     
-    opaque_bptree_t tree_data;
+    opaque_bptree_t *tree_data;
     IOStatus iostatus;
     iostatus = read_bptree_opaque(tree, &tree_data);
     err(iostatus != read_okay, "Tree read failed");
 
     ComputeStatus status;
-    status = one_off_matrix_fp32_v2t(table, &tree_data, method,
+    status = one_off_matrix_fp32_v2t(table, tree_data, method,
                                     false, 1.0, false, num_cores,
                                     0, true, NULL,
 				    &result);
@@ -171,11 +174,11 @@ void test_su_matrix_wtree2(int num_cores){
 		    0.5,        0.6,        0.85714286, 0.33333333, 0.0,        0.6,
                     0.2,        0.33333333, 0.42857143, 0.4,        0.6,        0.0        };
     
-    opaque_bptree_t tree_data;
+    opaque_bptree_t *tree_data;
     load_bptree_opaque(tree_str, &tree_data);
 
     ComputeStatus status;
-    status = one_off_matrix_fp32_v2t(table, &tree_data, method,
+    status = one_off_matrix_fp32_v2t(table, tree_data, method,
                                     false, 1.0, false, num_cores,
                                     0, true, NULL,
 				    &result);

--- a/test/capi_test.c
+++ b/test/capi_test.c
@@ -200,9 +200,11 @@ void test_su_dense(int num_cores){
     const char tree_str[] = "(GG_OTU_1:1,(GG_OTU_2:1,GG_OTU_3:1):1,(GG_OTU_5:1,GG_OTU_4:1):1);";
     const char* table_oids[] = { "GG_OTU_1", "GG_OTU_2", "GG_OTU_3", "GG_OTU_4", "GG_OTU_5" };
     const double sample1[] = { 0, 5, 0, 2, 0 };
+    const double sample2[] = { 0, 1, 0, 1, 1 };
     const double sample3[] = { 1, 0, 1, 1, 1 };
     const char* method = "unweighted";
     float exp13 = 0.57142857;
+    float exp21 = 0.2;
     
     opaque_bptree_t *tree_data;
     load_bptree_opaque(tree_str, &tree_data);
@@ -216,6 +218,15 @@ void test_su_dense(int num_cores){
     err(status != okay, "Compute failed");
 
     err(fabs(exp13 - result) > 0.00001, "Result is wrong");
+
+    status = one_dense_pair_v2t(5, table_oids, sample2, sample1,
+	                        tree_data, method,
+                                false, 1.0, false,
+				&result);
+
+    err(status != okay, "Compute failed");
+
+    err(fabs(exp21 - result) > 0.00001, "Result is wrong");
 
     destroy_bptree_opaque(&tree_data);
 }

--- a/test/capi_test.c
+++ b/test/capi_test.c
@@ -22,7 +22,7 @@ void test_su(int num_cores){
     const char* table = "test.biom";
     const char* tree = "test.tre";
     const char* method = "unweighted";
-    double exp[] = {0.2, 0.57142857, 0.6, 0.5, 0.2, 0.42857143, 0.66666667, 0.6, 0.33333333, 0.71428571, 0.85714286, 0.42857143, 0.33333333, 0.4, 0.6};
+    const double exp[] = {0.2, 0.57142857, 0.6, 0.5, 0.2, 0.42857143, 0.66666667, 0.6, 0.33333333, 0.71428571, 0.85714286, 0.42857143, 0.33333333, 0.4, 0.6};
     
     ComputeStatus status;
     status = one_off(table, tree, method,
@@ -44,13 +44,39 @@ void test_su_wtree(int num_cores){
     const char* table = "test.biom";
     const char* tree = "test.tre";
     const char* method = "unweighted";
-    double exp[] = {0.2, 0.57142857, 0.6, 0.5, 0.2, 0.42857143, 0.66666667, 0.6, 0.33333333, 0.71428571, 0.85714286, 0.42857143, 0.33333333, 0.4, 0.6};
+    const double exp[] = {0.2, 0.57142857, 0.6, 0.5, 0.2, 0.42857143, 0.66666667, 0.6, 0.33333333, 0.71428571, 0.85714286, 0.42857143, 0.33333333, 0.4, 0.6};
     
     opaque_bptree_t tree_data;
     IOStatus iostatus;
-    iostatus = load_bptree_opaque(tree, &tree_data);
+    iostatus = read_bptree_opaque(tree, &tree_data);
     err(iostatus != read_okay, "Tree read failed");
 
+
+    ComputeStatus status;
+    status = one_off_wtree(table, &tree_data, method,
+                     false, 1.0, false, num_cores, &result);
+
+    err(status != okay, "Compute failed");
+    err(result == NULL, "Empty result");
+    err(result->n_samples != 6, "Wrong number of samples");
+    err(result->cf_size != 15, "Wrong condensed form size");
+    err(!result->is_upper_triangle, "Result is not squaure");
+
+    for(unsigned int i = 0; i < result->cf_size; i++) 
+        err(fabs(exp[i] - result->condensed_form[i]) > 0.00001, "Result is wrong");
+
+    destroy_bptree_opaque(&tree_data);
+}
+
+void test_su_wtree2(int num_cores){
+    mat_t* result = NULL;
+    const char* table = "test.biom";
+    const char tree_str[] = "(GG_OTU_1:1,(GG_OTU_2:1,GG_OTU_3:1):1,(GG_OTU_5:1,GG_OTU_4:1):1);";
+    const char* method = "unweighted";
+    const double exp[] = {0.2, 0.57142857, 0.6, 0.5, 0.2, 0.42857143, 0.66666667, 0.6, 0.33333333, 0.71428571, 0.85714286, 0.42857143, 0.33333333, 0.4, 0.6};
+    
+    opaque_bptree_t tree_data;
+    load_bptree_opaque(tree_str, &tree_data);
 
     ComputeStatus status;
     status = one_off_wtree(table, &tree_data, method,
@@ -112,8 +138,41 @@ void test_su_matrix_wtree(int num_cores){
     
     opaque_bptree_t tree_data;
     IOStatus iostatus;
-    iostatus = load_bptree_opaque(tree, &tree_data);
+    iostatus = read_bptree_opaque(tree, &tree_data);
     err(iostatus != read_okay, "Tree read failed");
+
+    ComputeStatus status;
+    status = one_off_matrix_fp32_v2t(table, &tree_data, method,
+                                    false, 1.0, false, num_cores,
+                                    0, true, NULL,
+				    &result);
+
+    err(status != okay, "Compute failed");
+    err(result == NULL, "Empty result");
+    err(result->n_samples != 6, "Wrong number of samples");
+
+    for(unsigned int i = 0; i < (result->n_samples*result->n_samples); i++) 
+        err(fabs(exp[i] - result->matrix[i]) > 0.00001, "Result is wrong");
+
+
+    destroy_mat_full_fp32(&result);
+    destroy_bptree_opaque(&tree_data);
+}
+
+void test_su_matrix_wtree2(int num_cores){
+    mat_full_fp32_t* result = NULL;
+    const char* table = "test.biom";
+    const char tree_str[] = "(GG_OTU_1:1,(GG_OTU_2:1,GG_OTU_3:1):1,(GG_OTU_5:1,GG_OTU_4:1):1); \t "; //add final space, to exercise edge case
+    const char* method = "unweighted";
+    float exp[] = { 0.0,        0.2,        0.57142857, 0.6,        0.5,        0.2, 
+                    0.2,        0.0,        0.42857143, 0.66666667, 0.6,        0.33333333,
+		    0.57142857, 0.42857143, 0.0,        0.71428571, 0.85714286, 0.42857143, 
+		    0.6,        0.66666667, 0.71428571, 0.0,        0.33333333, 0.4,
+		    0.5,        0.6,        0.85714286, 0.33333333, 0.0,        0.6,
+                    0.2,        0.33333333, 0.42857143, 0.4,        0.6,        0.0        };
+    
+    opaque_bptree_t tree_data;
+    load_bptree_opaque(tree_str, &tree_data);
 
     ComputeStatus status;
     status = one_off_matrix_fp32_v2t(table, &tree_data, method,
@@ -137,7 +196,7 @@ void test_faith_pd(){
     r_vec* result = NULL;
     const char* table = "test.biom";
     const char* tree = "test.tre";
-    double exp[] = {4, 5, 6, 3, 2, 5};
+    const double exp[] = {4, 5, 6, 3, 2, 5};
 
     ComputeStatus status;
     status = faith_pd_one_off(table, tree, &result);
@@ -158,10 +217,12 @@ int main(int argc, char** argv) {
     test_su(num_cores);
     printf("Testing Striped UniFrac one_off_wtree...\n");
     test_su_wtree(num_cores);
+    test_su_wtree2(num_cores);
     printf("Testing Striped UniFrac one_off matrix...\n");
     test_su_matrix(num_cores);
     printf("Testing Striped UniFrac one_off matrix_wtree...\n");
     test_su_matrix_wtree(num_cores);
+    test_su_matrix_wtree2(num_cores);
     printf("Tests passed.\n");
     printf("Testing Faith's PD...\n");
     test_faith_pd();


### PR DESCRIPTION
Includes the notion of an opaque tree object, and the internal handling of dense input matrices.
Added several unit tests, some covering existing functionality.