### PR TITLE
Compile the accelerated code as a separate step

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -165,12 +165,12 @@ lib$(SSU).so: tree.o biom.o biom_inmem.o biom_subsampled.o tsv.o unifrac.o cmd.o
 api.o: api.cpp api.hpp unifrac.hpp skbio_alt.hpp biom.hpp biom_inmem.hpp biom_subsampled.hpp tree.hpp tsv.hpp
 	$(CXX) $(CPPFLAGS) api.cpp -c -o api.o -fPIC
 
-unifrac_cmp_cpu.o: unifrac_cmp.cpp unifrac_cmp.hpp unifrac_internal.hpp unifrac.hpp unifrac_task.cpp unifrac_task.hpp unifrac_task_noclass.hpp biom_interface.hpp tree.hpp
+unifrac_cmp_cpu.o: unifrac_cmp.cpp unifrac_cmp.hpp unifrac_internal.hpp unifrac.hpp unifrac_task_noclass.cpp unifrac_task.hpp unifrac_task_noclass.hpp biom_interface.hpp tree.hpp
 	$(CXX) $(CPPFLAGS) -c $< -o $@
 
-unifrac_cmp_acc.o: unifrac_cmp.cpp unifrac_cmp.hpp unifrac_internal.hpp unifrac.hpp unifrac_task.cpp unifrac_task.hpp unifrac_task_noclass.hpp biom_interface.hpp tree.hpp
+unifrac_cmp_acc.o: unifrac_cmp.cpp unifrac_cmp.hpp unifrac_internal.hpp unifrac.hpp unifrac_task_noclass.cpp unifrac_task.hpp unifrac_task_noclass.hpp biom_interface.hpp tree.hpp
 	$(CXX) $(CPPFLAGS) $(ACCCPPFLAGS) -c $< -o $@
-unifrac_cmp_ompgpu.o: unifrac_cmp.cpp unifrac_cmp.hpp unifrac_internal.hpp unifrac.hpp unifrac_task.cpp unifrac_task.hpp unifrac_task_noclass.hpp biom_interface.hpp tree.hpp
+unifrac_cmp_ompgpu.o: unifrac_cmp.cpp unifrac_cmp.hpp unifrac_internal.hpp unifrac.hpp unifrac_task_noclass.cpp unifrac_task.hpp unifrac_task_noclass.hpp biom_interface.hpp tree.hpp
 	$(CXX) $(CPPFLAGS) $(OMPGPUCPPFLAGS) -c $< -o $@
 
 %.o: %.cpp %.hpp

--- a/src/Makefile
+++ b/src/Makefile
@@ -165,12 +165,12 @@ lib$(SSU).so: tree.o biom.o biom_inmem.o biom_subsampled.o tsv.o unifrac.o cmd.o
 api.o: api.cpp api.hpp unifrac.hpp skbio_alt.hpp biom.hpp biom_inmem.hpp biom_subsampled.hpp tree.hpp tsv.hpp
 	$(CXX) $(CPPFLAGS) api.cpp -c -o api.o -fPIC
 
-unifrac_cmp_cpu.o: unifrac_cmp.cpp unifrac_cmp.hpp unifrac_internal.hpp unifrac.hpp unifrac_task.cpp unifrac_task.hpp biom_interface.hpp tree.hpp
+unifrac_cmp_cpu.o: unifrac_cmp.cpp unifrac_cmp.hpp unifrac_internal.hpp unifrac.hpp unifrac_task.cpp unifrac_task.hpp unifrac_task_noclass.hpp biom_interface.hpp tree.hpp
 	$(CXX) $(CPPFLAGS) -c $< -o $@
 
-unifrac_cmp_acc.o: unifrac_cmp.cpp unifrac_cmp.hpp unifrac_internal.hpp unifrac.hpp unifrac_task.cpp unifrac_task.hpp biom_interface.hpp tree.hpp
+unifrac_cmp_acc.o: unifrac_cmp.cpp unifrac_cmp.hpp unifrac_internal.hpp unifrac.hpp unifrac_task.cpp unifrac_task.hpp unifrac_task_noclass.hpp biom_interface.hpp tree.hpp
 	$(CXX) $(CPPFLAGS) $(ACCCPPFLAGS) -c $< -o $@
-unifrac_cmp_ompgpu.o: unifrac_cmp.cpp unifrac_cmp.hpp unifrac_internal.hpp unifrac.hpp unifrac_task.cpp unifrac_task.hpp biom_interface.hpp tree.hpp
+unifrac_cmp_ompgpu.o: unifrac_cmp.cpp unifrac_cmp.hpp unifrac_internal.hpp unifrac.hpp unifrac_task.cpp unifrac_task.hpp unifrac_task_noclass.hpp biom_interface.hpp tree.hpp
 	$(CXX) $(CPPFLAGS) $(OMPGPUCPPFLAGS) -c $< -o $@
 
 %.o: %.cpp %.hpp

--- a/src/Makefile
+++ b/src/Makefile
@@ -58,13 +58,13 @@ endif
 LDDFLAGS += $(MPFLAG)
 CPPFLAGS += $(MPFLAG)
 
-UNIFRAC_FILES = unifrac_internal.o unifrac_cmp_cpu.o
+UNIFRAC_FILES = unifrac_internal.o unifrac_task_cpu.o unifrac_cmp_cpu.o
 
 ifndef NOGPU
    ifeq ($(BUILD_OFFLOAD),ompgpu)
 	ifneq (,$(findstring pgi,$(COMPILER)))
 		CPPFLAGS += -DUNIFRAC_ENABLE_OMPGPU=1
-                UNIFRAC_FILES += unifrac_cmp_ompgpu.o
+                UNIFRAC_FILES += unifrac_task_ompgpu.o unifrac_cmp_ompgpu.o
 		OMPGPUCPPFLAGS += -mp=gpu -DOMPGPU=1 -noacc
 	        ifeq ($(PERFORMING_CONDA_BUILD),True)
 	            OMPGPUCPPFLAGS += -gpu=ccall
@@ -79,7 +79,7 @@ ifndef NOGPU
    else 
 	ifneq (,$(findstring pgi,$(COMPILER)))
 		CPPFLAGS += -DUNIFRAC_ENABLE_ACC=1
-                UNIFRAC_FILES += unifrac_cmp_acc.o
+                UNIFRAC_FILES += unifrac_task_acc.o unifrac_cmp_acc.o
 		ACCCPPFLAGS += -acc
 	        ifeq ($(PERFORMING_CONDA_BUILD),True)
 	            ACCCPPFLAGS += -gpu=ccall
@@ -165,13 +165,21 @@ lib$(SSU).so: tree.o biom.o biom_inmem.o biom_subsampled.o tsv.o unifrac.o cmd.o
 api.o: api.cpp api.hpp unifrac.hpp skbio_alt.hpp biom.hpp biom_inmem.hpp biom_subsampled.hpp tree.hpp tsv.hpp
 	$(CXX) $(CPPFLAGS) api.cpp -c -o api.o -fPIC
 
-unifrac_cmp_cpu.o: unifrac_cmp.cpp unifrac_cmp.hpp unifrac_internal.hpp unifrac.hpp unifrac_task_noclass.cpp unifrac_task.hpp unifrac_task_noclass.hpp biom_interface.hpp tree.hpp
-	$(CXX) $(CPPFLAGS) -c $< -o $@
+unifrac_task_cpu.o: unifrac_task_noclass.cpp unifrac_task_noclass.hpp
+	$(CXX) $(CPPFLAGS) -DSUCMP_NM=su_cpu -c $< -o $@
 
-unifrac_cmp_acc.o: unifrac_cmp.cpp unifrac_cmp.hpp unifrac_internal.hpp unifrac.hpp unifrac_task_noclass.cpp unifrac_task.hpp unifrac_task_noclass.hpp biom_interface.hpp tree.hpp
-	$(CXX) $(CPPFLAGS) $(ACCCPPFLAGS) -c $< -o $@
-unifrac_cmp_ompgpu.o: unifrac_cmp.cpp unifrac_cmp.hpp unifrac_internal.hpp unifrac.hpp unifrac_task_noclass.cpp unifrac_task.hpp unifrac_task_noclass.hpp biom_interface.hpp tree.hpp
-	$(CXX) $(CPPFLAGS) $(OMPGPUCPPFLAGS) -c $< -o $@
+unifrac_task_acc.o: unifrac_task_noclass.cpp unifrac_task_noclass.hpp
+	$(CXX) $(CPPFLAGS) $(ACCCPPFLAGS) -DSUCMP_NM=su_acc -c $< -o $@
+unifrac_task_ompgpu.o: unifrac_task_noclass.cpp unifrac_task_noclass.hpp
+	$(CXX) $(CPPFLAGS) $(OMPGPUCPPFLAGS) -DSUCMP_NM=su_ompgpu -c $< -o $@
+
+unifrac_cmp_cpu.o: unifrac_cmp.cpp unifrac_cmp.hpp unifrac_internal.hpp unifrac.hpp unifrac_task.hpp unifrac_task_noclass.hpp biom_interface.hpp tree.hpp
+	$(CXX) $(CPPFLAGS) -DSUCMP_NM=su_cpu -c $< -o $@
+
+unifrac_cmp_acc.o: unifrac_cmp.cpp unifrac_cmp.hpp unifrac_internal.hpp unifrac.hpp unifrac_task.hpp unifrac_task_noclass.hpp biom_interface.hpp tree.hpp
+	$(CXX) $(CPPFLAGS) $(ACCCPPFLAGS) -DSUCMP_NM=su_acc -c $< -o $@
+unifrac_cmp_ompgpu.o: unifrac_cmp.cpp unifrac_cmp.hpp unifrac_internal.hpp unifrac.hpp unifrac_task.hpp unifrac_task_noclass.hpp biom_interface.hpp tree.hpp
+	$(CXX) $(CPPFLAGS) $(OMPGPUCPPFLAGS) -DSUCMP_NM=su_ompgpu -c $< -o $@
 
 %.o: %.cpp %.hpp
 	$(CXX) $(CPPFLAGS) -c $< -o $@

--- a/src/unifrac_cmp.cpp
+++ b/src/unifrac_cmp.cpp
@@ -31,12 +31,12 @@
 
 #endif
 
+// embed in this file, to properly instantiate the templatized functions
+#include "unifrac_task_noclass.cpp"
+
 #include "unifrac_task.hpp"
 // Note: unifrac_task.hpp defines SUCMP_NM, needed by unifrac_cmp.hpp
 #include "unifrac_cmp.hpp"
-
-// embed in this file, to properly instantiate the templatized functions
-#include "unifrac_task.cpp"
 
 using namespace SUCMP_NM;
 

--- a/src/unifrac_cmp.cpp
+++ b/src/unifrac_cmp.cpp
@@ -14,31 +14,17 @@
 #include <thread>
 #include <algorithm>
 
-#include "unifrac_internal.hpp"
-
-// We must explicitly set SUCMP_NM, to distinguish between the various flavors
-#if defined(OMPGPU)
-
-#define SUCMP_NM su_ompgpu
-
-#elif defined(_OPENACC)
-
-#define SUCMP_NM su_acc
-
-#else
-
-#define SUCMP_NM su_cpu
-
-#endif
-
-// embed in this file, to properly instantiate the templatized functions
-#include "unifrac_task_noclass.cpp"
-
-#include "unifrac_task.hpp"
-// Note: unifrac_task.hpp defines SUCMP_NM, needed by unifrac_cmp.hpp
 #include "unifrac_cmp.hpp"
+#include "unifrac_internal.hpp"
+#include "unifrac_task.hpp"
 
 using namespace SUCMP_NM;
+
+// do we have access to a GPU?
+// Just a wrapper, to expose it to the rest of the code
+bool SUCMP_NM::found_gpu() {
+  return acc_found_gpu();
+}
 
 template<class TaskT, class TFloat>
 inline void unifracTT(const su::biom_interface &table,

--- a/src/unifrac_cmp.hpp
+++ b/src/unifrac_cmp.hpp
@@ -17,6 +17,11 @@
 
 #include "unifrac_internal.hpp"
 
+#ifndef SUCMP_NM
+/* create a default */
+#define SUCMP_NM su_cpu
+#endif
+
 namespace SUCMP_NM {
 
   // Returns True iff a GPU can be used

--- a/src/unifrac_cmp.hpp
+++ b/src/unifrac_cmp.hpp
@@ -7,8 +7,6 @@
  * See LICENSE file for more details
  */
 
-#ifdef SUCMP_NM
-
 /* Note: Allow multiple definitions of this header, using different SUCMP_NM */
 
 #include "task_parameters.hpp"
@@ -43,4 +41,3 @@ namespace SUCMP_NM {
 
 }
 
-#endif /* SUCMP_NM */

--- a/src/unifrac_task.cpp
+++ b/src/unifrac_task.cpp
@@ -627,18 +627,15 @@ void SUCMP_NM::run_UnnormalizedWeightedTask(
 }
 
 template<class TFloat>
-void SUCMP_NM::UnifracVawUnnormalizedWeightedTask<TFloat>::_run(unsigned int filled_embs) {
-    const uint64_t start_idx = this->task_p->start;
-    const uint64_t stop_idx = this->task_p->stop;
-    const uint64_t n_samples = this->task_p->n_samples;
-    const uint64_t n_samples_r = this->dm_stripes.n_samples_r;
-
-    // openacc only works well with local variables
-    const TFloat * const __restrict__ lengths = this->lengths;
-    const TFloat * const __restrict__ embedded_proportions = this->get_embedded_proportions();
-    const TFloat * const __restrict__ embedded_counts = this->embedded_counts;
-    const TFloat * const __restrict__ sample_total_counts = this->sample_total_counts;
-    TFloat * const __restrict__ dm_stripes_buf = this->dm_stripes.buf;
+void SUCMP_NM::run_VawUnnormalizedWeightedTask(
+		const unsigned int filled_embs,
+		const uint64_t start_idx, const uint64_t stop_idx,
+		const uint64_t n_samples, const uint64_t n_samples_r,
+		const TFloat * const __restrict__ lengths,
+		const TFloat * const __restrict__ embedded_proportions,
+		const TFloat * const __restrict__ embedded_counts,
+		const TFloat * const __restrict__ sample_total_counts,
+		TFloat * const __restrict__ dm_stripes_buf) {
 
     constexpr uint64_t step_size = STEP_SIZE(TFloat);
     const uint64_t sample_steps = (n_samples+(step_size-1))/step_size; // round up
@@ -696,9 +693,6 @@ void SUCMP_NM::UnifracVawUnnormalizedWeightedTask<TFloat>::_run(unsigned int fil
 
       }
     }
-
-   // next iteration will use the alternative space
-   this->set_alt_embedded_proportions();
 }
 
 // Single step in computing NormalizedWeighted Unifrac
@@ -972,20 +966,16 @@ static inline void NormalizedWeighted8(
 #endif
 
 template<class TFloat>
-void SUCMP_NM::UnifracNormalizedWeightedTask<TFloat>::_run(unsigned int filled_embs) {
-    const uint64_t start_idx = this->task_p->start;
-    const uint64_t stop_idx = this->task_p->stop;
-    const uint64_t n_samples = this->task_p->n_samples;
-    const uint64_t n_samples_r = this->dm_stripes.n_samples_r;
-
-    // openacc only works well with local variables
-    const TFloat * const __restrict__ lengths = this->lengths;
-    const TFloat * const __restrict__ embedded_proportions = this->get_embedded_proportions();
-    TFloat * const __restrict__ dm_stripes_buf = this->dm_stripes.buf;
-    TFloat * const __restrict__ dm_stripes_total_buf = this->dm_stripes_total.buf;
-
-    bool * const __restrict__ zcheck = this->zcheck;
-    TFloat * const __restrict__ sums = this->sums;
+void SUCMP_NM::run_NormalizedWeightedTask(
+		const unsigned int filled_embs,
+		const uint64_t start_idx, const uint64_t stop_idx,
+		const uint64_t n_samples, const uint64_t n_samples_r,
+		const TFloat * const __restrict__ lengths,
+		const TFloat * const __restrict__ embedded_proportions,
+		TFloat * const __restrict__ dm_stripes_buf,
+		TFloat * const __restrict__ dm_stripes_total_buf,
+		bool * const __restrict__ zcheck,
+		TFloat * const __restrict__ sums) {
 
     constexpr uint64_t step_size = STEP_SIZE(TFloat);
     const uint64_t sample_steps = (n_samples+(step_size-1))/step_size; // round up
@@ -1078,25 +1068,19 @@ void SUCMP_NM::UnifracNormalizedWeightedTask<TFloat>::_run(unsigned int filled_e
      } // for sk
     } // for ss
 #endif
-
-   // next iteration will use the alternative space
-   this->set_alt_embedded_proportions();
 }
 
 template<class TFloat>
-void SUCMP_NM::UnifracVawNormalizedWeightedTask<TFloat>::_run(unsigned int filled_embs) {
-    const uint64_t start_idx = this->task_p->start;
-    const uint64_t stop_idx = this->task_p->stop;
-    const uint64_t n_samples = this->task_p->n_samples;
-    const uint64_t n_samples_r = this->dm_stripes.n_samples_r;
-
-    // openacc only works well with local variables
-    const TFloat * const __restrict__ lengths = this->lengths;
-    const TFloat * const __restrict__ embedded_proportions = this->get_embedded_proportions();
-    const TFloat * const __restrict__ embedded_counts = this->embedded_counts;
-    const TFloat * const __restrict__ sample_total_counts = this->sample_total_counts;
-    TFloat * const __restrict__ dm_stripes_buf = this->dm_stripes.buf;
-    TFloat * const __restrict__ dm_stripes_total_buf = this->dm_stripes_total.buf;
+void SUCMP_NM::run_VawNormalizedWeightedTask(
+		const unsigned int filled_embs,
+		const uint64_t start_idx, const uint64_t stop_idx,
+		const uint64_t n_samples, const uint64_t n_samples_r,
+		const TFloat * const __restrict__ lengths,
+		const TFloat * const __restrict__ embedded_proportions,
+		const TFloat * const __restrict__ embedded_counts,
+		const TFloat * const __restrict__ sample_total_counts,
+		TFloat * const __restrict__ dm_stripes_buf,
+		TFloat * const __restrict__ dm_stripes_total_buf) {
 
     constexpr uint64_t step_size = STEP_SIZE(TFloat);
     const uint64_t sample_steps = (n_samples+(step_size-1))/step_size; // round up
@@ -1160,9 +1144,6 @@ void SUCMP_NM::UnifracVawNormalizedWeightedTask<TFloat>::_run(unsigned int fille
 
       }
     }
-
-   // next iteration will use the alternative space
-   this->set_alt_embedded_proportions();
 }
 
 template<class TFloat>

--- a/src/unifrac_task.cpp
+++ b/src/unifrac_task.cpp
@@ -18,6 +18,9 @@
 
 #endif
 
+// Use a moderate sized step, a few cache lines
+#define STEP_SIZE(TFloat) (64*4/sizeof(TFloat))
+
 bool SUCMP_NM::found_gpu() {
 #if defined(OMPGPU)
   return omp_get_num_devices() > 0;
@@ -555,7 +558,7 @@ void SUCMP_NM::UnifracUnnormalizedWeightedTask<TFloat>::_run(unsigned int filled
     bool * const __restrict__ zcheck = this->zcheck;
     TFloat * const __restrict__ sums = this->sums;
 
-    const uint64_t step_size = SUCMP_NM::UnifracUnnormalizedWeightedTask<TFloat>::step_size;
+    constexpr uint64_t step_size = STEP_SIZE(TFloat);
     const uint64_t sample_steps = (n_samples+(step_size-1))/step_size; // round up
 
     // check for zero values and pre-compute single column sums
@@ -665,7 +668,7 @@ void SUCMP_NM::UnifracVawUnnormalizedWeightedTask<TFloat>::_run(unsigned int fil
     const TFloat * const __restrict__ sample_total_counts = this->sample_total_counts;
     TFloat * const __restrict__ dm_stripes_buf = this->dm_stripes.buf;
 
-    const uint64_t step_size = SUCMP_NM::UnifracVawUnnormalizedWeightedTask<TFloat>::step_size;
+    constexpr uint64_t step_size = STEP_SIZE(TFloat);
     const uint64_t sample_steps = (n_samples+(step_size-1))/step_size; // round up
 
     // point of thread
@@ -1012,7 +1015,7 @@ void SUCMP_NM::UnifracNormalizedWeightedTask<TFloat>::_run(unsigned int filled_e
     bool * const __restrict__ zcheck = this->zcheck;
     TFloat * const __restrict__ sums = this->sums;
 
-    const uint64_t step_size = SUCMP_NM::UnifracNormalizedWeightedTask<TFloat>::step_size;
+    constexpr uint64_t step_size = STEP_SIZE(TFloat);
     const uint64_t sample_steps = (n_samples+(step_size-1))/step_size; // round up
 
     // check for zero values and pre-compute single column sums
@@ -1123,7 +1126,7 @@ void SUCMP_NM::UnifracVawNormalizedWeightedTask<TFloat>::_run(unsigned int fille
     TFloat * const __restrict__ dm_stripes_buf = this->dm_stripes.buf;
     TFloat * const __restrict__ dm_stripes_total_buf = this->dm_stripes_total.buf;
 
-    const uint64_t step_size = SUCMP_NM::UnifracVawNormalizedWeightedTask<TFloat>::step_size;
+    constexpr uint64_t step_size = STEP_SIZE(TFloat);
     const uint64_t sample_steps = (n_samples+(step_size-1))/step_size; // round up
 
     // point of thread
@@ -1205,7 +1208,7 @@ void SUCMP_NM::UnifracGeneralizedTask<TFloat>::_run(unsigned int filled_embs) {
 
     const TFloat g_unifrac_alpha = this->task_p->g_unifrac_alpha;
 
-    const uint64_t step_size = SUCMP_NM::UnifracGeneralizedTask<TFloat>::step_size;
+    constexpr uint64_t step_size = STEP_SIZE(TFloat);
     const uint64_t sample_steps = (n_samples+(step_size-1))/step_size; // round up
 
     // point of thread
@@ -1287,7 +1290,7 @@ void SUCMP_NM::UnifracVawGeneralizedTask<TFloat>::_run(unsigned int filled_embs)
     TFloat * const __restrict__ dm_stripes_buf = this->dm_stripes.buf;
     TFloat * const __restrict__ dm_stripes_total_buf = this->dm_stripes_total.buf;
 
-    const uint64_t step_size = SUCMP_NM::UnifracVawGeneralizedTask<TFloat>::step_size;
+    constexpr uint64_t step_size = STEP_SIZE(TFloat);
     const uint64_t sample_steps = (n_samples+(step_size-1))/step_size; // round up
     // quick hack, to be finished
 
@@ -1707,7 +1710,7 @@ void SUCMP_NM::UnifracUnweightedTask<TFloat>::_run(unsigned int filled_embs) {
     bool   * const __restrict__ zcheck = this->zcheck;
     TFloat * const __restrict__ stripe_sums = this->stripe_sums;
 
-    const uint64_t step_size = SUCMP_NM::UnifracUnweightedTask<TFloat>::step_size;
+    constexpr uint64_t step_size = STEP_SIZE(TFloat);
     const uint64_t sample_steps = (n_samples+(step_size-1))/step_size; // round up
 
     const uint64_t filled_embs_els = filled_embs/64;
@@ -1874,7 +1877,7 @@ void SUCMP_NM::UnifracUnnormalizedUnweightedTask<TFloat>::_run(unsigned int fill
     bool   * const __restrict__ zcheck = this->zcheck;
     TFloat * const __restrict__ stripe_sums = this->stripe_sums;
 
-    const uint64_t step_size = SUCMP_NM::UnifracUnweightedTask<TFloat>::step_size;
+    constexpr uint64_t step_size = STEP_SIZE(TFloat);
     const uint64_t sample_steps = (n_samples+(step_size-1))/step_size; // round up
 
     const uint64_t filled_embs_els = filled_embs/64;
@@ -2039,7 +2042,7 @@ void SUCMP_NM::UnifracVawUnweightedTask<TFloat>::_run(unsigned int filled_embs) 
     TFloat * const __restrict__ dm_stripes_buf = this->dm_stripes.buf;
     TFloat * const __restrict__ dm_stripes_total_buf = this->dm_stripes_total.buf;
 
-    const uint64_t step_size = SUCMP_NM::UnifracVawUnweightedTask<TFloat>::step_size;
+    constexpr uint64_t step_size = STEP_SIZE(TFloat);
     const uint64_t sample_steps = (n_samples+(step_size-1))/step_size; // round up
 
     const uint64_t filled_embs_els = (filled_embs+31)/32; // round up
@@ -2137,7 +2140,7 @@ void SUCMP_NM::UnifracVawUnnormalizedUnweightedTask<TFloat>::_run(unsigned int f
     const TFloat  * const __restrict__ sample_total_counts = this->sample_total_counts;
     TFloat * const __restrict__ dm_stripes_buf = this->dm_stripes.buf;
 
-    const uint64_t step_size = SUCMP_NM::UnifracVawUnweightedTask<TFloat>::step_size;
+    constexpr uint64_t step_size = STEP_SIZE(TFloat);
     const uint64_t sample_steps = (n_samples+(step_size-1))/step_size; // round up
 
     const uint64_t filled_embs_els = (filled_embs+31)/32; // round up

--- a/src/unifrac_task.cpp
+++ b/src/unifrac_task.cpp
@@ -523,19 +523,15 @@ static inline void UnnormalizedWeighted8(
 #endif
 
 template<class TFloat>
-void SUCMP_NM::UnifracUnnormalizedWeightedTask<TFloat>::_run(unsigned int filled_embs) {
-    const uint64_t start_idx = this->task_p->start;
-    const uint64_t stop_idx = this->task_p->stop;
-    const uint64_t n_samples = this->task_p->n_samples;
-    const uint64_t n_samples_r = this->dm_stripes.n_samples_r;
-
-    // openacc only works well with local variables
-    const TFloat * const __restrict__ lengths = this->lengths;
-    const TFloat * const __restrict__ embedded_proportions = this->get_embedded_proportions();
-    TFloat * const __restrict__ dm_stripes_buf = this->dm_stripes.buf;
-
-    bool * const __restrict__ zcheck = this->zcheck;
-    TFloat * const __restrict__ sums = this->sums;
+void SUCMP_NM::run_UnnormalizedWeightedTask(
+		const unsigned int filled_embs,
+		const uint64_t start_idx, const uint64_t stop_idx,
+		const uint64_t n_samples, const uint64_t n_samples_r,
+		const TFloat * const __restrict__ lengths,
+		const TFloat * const __restrict__ embedded_proportions,
+		TFloat * const __restrict__ dm_stripes_buf,
+		bool * const __restrict__ zcheck,
+		TFloat * const __restrict__ sums) {
 
     constexpr uint64_t step_size = STEP_SIZE(TFloat);
     const uint64_t sample_steps = (n_samples+(step_size-1))/step_size; // round up
@@ -628,9 +624,6 @@ void SUCMP_NM::UnifracUnnormalizedWeightedTask<TFloat>::_run(unsigned int filled
      } // for sk
     } // for ss
 #endif
-
-   // next iteration will use the alternative space
-   this->set_alt_embedded_proportions();
 }
 
 template<class TFloat>

--- a/src/unifrac_task.cpp
+++ b/src/unifrac_task.cpp
@@ -84,26 +84,6 @@ void SUCMP_NM::acc_destroy_buf(T *buf, uint64_t start, uint64_t end) {
 #endif
 }
 
-template<class TFloat>
-uint64_t SUCMP_NM::UnifracTaskVector<TFloat>::block_round(uint64_t bufsize) {
-#if defined(_OPENACC) || defined(OMPGPU)
-
-#ifndef SMALLGPU
-  // defaultt on larger alignment, which improves performance on GPUs like V100
-  const uint64_t UNIFRAC_BLOCK=64;
-#else
-  // smaller GPUs prefer smaller allignment 
-  const uint64_t UNIFRAC_BLOCK=32;
-#endif
-
-#else
-  // CPUs don't need such a big alignment
-  const uint64_t UNIFRAC_BLOCK=16;
-#endif
-
-  return ((bufsize + UNIFRAC_BLOCK-1)/UNIFRAC_BLOCK)*UNIFRAC_BLOCK; // round up
-}
-
 // is the implementation async, and need the alt structures?
 template<class TFloat, class TEmb>
 bool SUCMP_NM::UnifracTaskBase<TFloat,TEmb>::need_alt() {

--- a/src/unifrac_task.cpp
+++ b/src/unifrac_task.cpp
@@ -94,12 +94,11 @@ bool SUCMP_NM::UnifracTaskBase<TFloat,TEmb>::need_alt() {
 #endif
 }
 
-template<class TFloat, class TEmb>
-void SUCMP_NM::UnifracTaskBase<TFloat,TEmb>::compute_totals() {         
-         TFloat * const __restrict__ dm_stripes_buf = this->dm_stripes.buf;
-   const TFloat * const __restrict__ dm_stripes_total_buf = this->dm_stripes_total.buf;
-   const uint64_t bufels = this->dm_stripes.bufels;
-
+template<class TFloat>
+void SUCMP_NM::compute_stripes_totals(
+		TFloat * const __restrict__ dm_stripes_buf,
+		const TFloat * const __restrict__ dm_stripes_total_buf,
+		const uint64_t bufels) { 
 #if defined(OMPGPU)
 #pragma omp target teams distribute parallel for simd default(shared)
 #elif defined(_OPENACC)

--- a/src/unifrac_task.hpp
+++ b/src/unifrac_task.hpp
@@ -70,7 +70,7 @@ namespace SUCMP_NM {
       UnifracTaskVector(std::vector<double*> &_dm_stripes, const su::task_parameters* _task_p)
       : dm_stripes(_dm_stripes), task_p(_task_p)
       , start_idx(task_p->start), stop_idx(task_p->stop), n_samples(task_p->n_samples)
-      , n_samples_r(block_round(n_samples))
+      , n_samples_r(((n_samples + 64-1)/64)*64) // round up to 64 elements (2kbit/4kbits)
       , bufels(n_samples_r * (stop_idx-start_idx))
       , buf((dm_stripes[start_idx]==NULL) ? NULL : (TFloat*) malloc(sizeof(TFloat) * bufels)) // dm_stripes could be null, in which case keep it null
       {
@@ -118,8 +118,6 @@ namespace SUCMP_NM {
           free(buf);
         }
       }
-
-      static uint64_t block_round(uint64_t bufsize);
 
     private:
       UnifracTaskVector() = delete;

--- a/src/unifrac_task.hpp
+++ b/src/unifrac_task.hpp
@@ -390,7 +390,17 @@ namespace SUCMP_NM {
 
         virtual void run(unsigned int filled_embs) {_run(filled_embs);}
 
-        void _run(unsigned int filled_embs);
+        void _run(unsigned int filled_embs) {
+          run_NormalizedWeightedTask(
+			    filled_embs,
+			    this->task_p->start, this->task_p->stop, this->task_p->n_samples, this->dm_stripes.n_samples_r,
+			    this->lengths, this->get_embedded_proportions(),
+			    this->dm_stripes.buf, this->dm_stripes_total.buf,
+			    this->zcheck, this->sums);
+
+          // next iteration will use the alternative space
+          this->set_alt_embedded_proportions();
+	}
       protected:
         // temp buffers
         bool     *zcheck;
@@ -576,7 +586,16 @@ namespace SUCMP_NM {
 
         virtual void run(unsigned int filled_embs) {_run(filled_embs);}
 
-        void _run(unsigned int filled_embs);
+        void _run(unsigned int filled_embs) {
+           run_VawUnnormalizedWeightedTask(
+			   filled_embs,
+			   this->task_p->start, this->task_p->stop, this->task_p->n_samples, this->dm_stripes.n_samples_r,
+			   this->lengths, this->get_embedded_proportions(), this->embedded_counts, this->sample_total_counts,
+			   this->dm_stripes.buf);
+
+           // next iteration will use the alternative space
+           this->set_alt_embedded_proportions();
+	}
     };
     template<class TFloat>
     class UnifracVawNormalizedWeightedTask : public UnifracVawTask<TFloat,TFloat> {
@@ -591,7 +610,16 @@ namespace SUCMP_NM {
 
         virtual void run(unsigned int filled_embs) {_run(filled_embs);}
 
-        void _run(unsigned int filled_embs);
+        void _run(unsigned int filled_embs) {
+          run_VawNormalizedWeightedTask(
+			  filled_embs,
+			  this->task_p->start, this->task_p->stop, this->task_p->n_samples, this->dm_stripes.n_samples_r,
+			  this->lengths, this->get_embedded_proportions(), this->embedded_counts, this->sample_total_counts,
+			  this->dm_stripes.buf, this->dm_stripes_total.buf);
+
+          // next iteration will use the alternative space
+          this->set_alt_embedded_proportions();
+	}
     };
     template<class TFloat>
     class UnifracVawUnweightedTask : public UnifracVawTask<TFloat,uint32_t> {

--- a/src/unifrac_task.hpp
+++ b/src/unifrac_task.hpp
@@ -19,6 +19,11 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#ifndef SUCMP_NM
+/* create a default */
+#define SUCMP_NM su_cpu
+#endif
+
 namespace SUCMP_NM {
 
     // Note: This adds a copy, which is suboptimal

--- a/src/unifrac_task.hpp
+++ b/src/unifrac_task.hpp
@@ -554,7 +554,7 @@ namespace SUCMP_NM {
         , sample_total_counts(initialize_sample_counts(this->dm_stripes.n_samples, this->dm_stripes.n_samples_r, _task_p, _sample_counts))
         {
           acc_create_buf(embedded_counts, 0, this->embsize);
-          acc_copyin_buf(sample_total_counts, 0 , this->dm_stripes.n_samples_r);
+          acc_copyin_buf(const_cast<TFloat *>(sample_total_counts), 0 , this->dm_stripes.n_samples_r); // const after the contructor
         }
 
        UnifracVawTask(const UnifracVawTask<TFloat,TEmb>& ) = delete;
@@ -562,10 +562,10 @@ namespace SUCMP_NM {
 
        virtual ~UnifracVawTask() 
        {
-          acc_destroy_buf(sample_total_counts, 0 , this->dm_stripes.n_samples_r);
+          acc_destroy_buf(const_cast<TFloat *>(sample_total_counts), 0 , this->dm_stripes.n_samples_r);
           acc_destroy_buf(embedded_counts, 0, this->embsize);
 
-          free((void*) sample_total_counts); // while const for the life of this, not const past its lifetime
+          free(const_cast<TFloat *>(sample_total_counts)); // while const for the life of this, not const past its lifetime
           free(embedded_counts);
        }
 

--- a/src/unifrac_task.hpp
+++ b/src/unifrac_task.hpp
@@ -459,7 +459,16 @@ namespace SUCMP_NM {
 
         virtual void run(unsigned int filled_embs) {_run(filled_embs);}
 
-        void _run(unsigned int filled_embs);
+        void _run(unsigned int filled_embs) {
+          run_UnweightedTask(
+			 filled_embs,
+			 this->task_p->start, this->task_p->stop, this->task_p->n_samples, this->dm_stripes.n_samples_r,
+			 this->lengths, this->get_embedded_proportions(), this->dm_stripes.buf, this->dm_stripes_total.buf,
+			 this->sums, this->zcheck, this->stripe_sums);
+
+          // next iteration will use the alternative space
+          this->set_alt_embedded_proportions();
+	}
     };
     template<class TFloat>
     class UnifracUnnormalizedUnweightedTask : public UnifracCommonUnweightedTask<TFloat> {
@@ -474,7 +483,17 @@ namespace SUCMP_NM {
 
         virtual void run(unsigned int filled_embs) {_run(filled_embs);}
 
-        void _run(unsigned int filled_embs);
+        void _run(unsigned int filled_embs) {
+          run_UnnormalizedUnweightedTask(
+			  filled_embs,
+			  this->task_p->start, this->task_p->stop, this->task_p->n_samples, this->dm_stripes.n_samples_r,
+			  this->lengths, this->get_embedded_proportions(),
+			  this->dm_stripes.buf,
+			  this->sums, this->zcheck, this->stripe_sums);
+
+          // next iteration will use the alternative space
+          this->set_alt_embedded_proportions();
+	}
     };
 
     template<class TFloat>
@@ -490,7 +509,17 @@ namespace SUCMP_NM {
 
         virtual void run(unsigned int filled_embs) {_run(filled_embs);}
 
-        void _run(unsigned int filled_embs);
+        void _run(unsigned int filled_embs) {
+          run_GeneralizedTask(
+			  filled_embs,
+			  this->task_p->start, this->task_p->stop, this->task_p->n_samples, this->dm_stripes.n_samples_r,
+			  this->lengths, this->get_embedded_proportions(),
+			  this->dm_stripes.buf, this->dm_stripes_total.buf,
+			  (TFloat) this->task_p->g_unifrac_alpha);
+
+          // next iteration will use the alternative space
+          this->set_alt_embedded_proportions();
+	}
     };
 
     /* void unifrac_vaw tasks
@@ -634,7 +663,16 @@ namespace SUCMP_NM {
 
         virtual void run(unsigned int filled_embs) {_run(filled_embs);}
 
-        void _run(unsigned int filled_embs);
+        void _run(unsigned int filled_embs) {
+          run_VawUnweightedTask(
+			  filled_embs,
+			  this->task_p->start, this->task_p->stop, this->task_p->n_samples, this->dm_stripes.n_samples_r,
+			  this->lengths, this->get_embedded_proportions(), this->embedded_counts, this->sample_total_counts,
+			  this->dm_stripes.buf, this->dm_stripes_total.buf);
+
+          // next iteration will use the alternative space
+          this->set_alt_embedded_proportions();
+	}
     };
     template<class TFloat>
     class UnifracVawUnnormalizedUnweightedTask : public UnifracVawTask<TFloat,uint32_t> {
@@ -649,7 +687,16 @@ namespace SUCMP_NM {
 
         virtual void run(unsigned int filled_embs) {_run(filled_embs);}
 
-        void _run(unsigned int filled_embs);
+        void _run(unsigned int filled_embs) {
+          run_VawUnnormalizedUnweightedTask(
+			  filled_embs,
+			  this->task_p->start, this->task_p->stop, this->task_p->n_samples, this->dm_stripes.n_samples_r,
+			  this->lengths, this->get_embedded_proportions(), this->embedded_counts, this->sample_total_counts,
+			  this->dm_stripes.buf);
+
+          // next iteration will use the alternative space
+          this->set_alt_embedded_proportions();
+	}
     };
     template<class TFloat>
     class UnifracVawGeneralizedTask : public UnifracVawTask<TFloat,TFloat> {
@@ -664,7 +711,17 @@ namespace SUCMP_NM {
 
         virtual void run(unsigned int filled_embs) {_run(filled_embs);}
 
-        void _run(unsigned int filled_embs);
+        void _run(unsigned int filled_embs) {
+          run_VawGeneralizedTask(
+			  filled_embs,
+			  this->task_p->start, this->task_p->stop, this->task_p->n_samples, this->dm_stripes.n_samples_r,
+			  this->lengths, this->get_embedded_proportions(), this->embedded_counts,this->sample_total_counts,
+			  this->dm_stripes.buf, this->dm_stripes_total.buf,
+			  (TFloat) this->task_p->g_unifrac_alpha);
+
+          // next iteration will use the alternative space
+          this->set_alt_embedded_proportions();
+	}
     };
 
 }

--- a/src/unifrac_task.hpp
+++ b/src/unifrac_task.hpp
@@ -7,6 +7,10 @@
  * See LICENSE file for more details
  */
 
+#ifndef __UNIFRAC_TASKS
+#define __UNIFRAC_TASKS 1
+
+#include "unifrac_task_noclass.hpp"
 #include "task_parameters.hpp"
 #include <math.h>
 #include <vector>
@@ -15,40 +19,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-
-#ifndef __UNIFRAC_TASKS
-#define __UNIFRAC_TASKS 1
-
 namespace SUCMP_NM {
-
-    // do we have access to a GPU?
-    bool found_gpu();
-
-    // wait for the async compute to finish
-    void acc_wait();
-
-    // create the equivalent buffer in the device memory space, if partitioned
-    // the content in undefined
-    template<class T>
-    void acc_create_buf(T *buf, uint64_t start, uint64_t end);
-
-    // create the equivalent buffer in the device memory space, if partitioned
-    // also copy the buffer over
-    template<class T>
-    void acc_copyin_buf(T *buf, uint64_t start, uint64_t end);
-
-    // make a copy from host to device buffer, if partitioned
-    template<class T>
-    void acc_update_device(T *buf, uint64_t start, uint64_t end);
-
-    // make a copy from device to host buffer, if partitioned
-    // destroy the equivalent buffer in the device memory space, if partitioned
-    template<class T>
-    void acc_copyout_buf(T *buf, uint64_t start, uint64_t end);
-
-    // destroy the equivalent buffer in the device memory space, if partitioned
-    template<class T>
-    void acc_destroy_buf(T *buf, uint64_t start, uint64_t end);
 
     // Note: This adds a copy, which is suboptimal
     //       But was the easiest way to get a contiguous buffer

--- a/src/unifrac_task.hpp
+++ b/src/unifrac_task.hpp
@@ -320,10 +320,6 @@ namespace SUCMP_NM {
 
     template<class TFloat, class TEmb>
     class UnifracTask : public UnifracTaskBase<TFloat,TEmb> {
-      protected:
-        // Use a moderate sized step, a few cache lines
-        static constexpr unsigned int step_size = 64*4/sizeof(TFloat);
-
       public:
 
         UnifracTask(std::vector<double*> &_dm_stripes, std::vector<double*> &_dm_stripes_total, unsigned int _max_embs, const su::task_parameters* _task_p)
@@ -423,8 +419,6 @@ namespace SUCMP_NM {
     template<class TFloat>
     class UnifracCommonUnweightedTask : public UnifracTask<TFloat,uint64_t> {
       public:
-        static constexpr unsigned int step_size = 64*4/sizeof(TFloat);
-
         static constexpr unsigned int RECOMMENDED_MAX_EMBS = UnifracTask<TFloat,uint64_t>::RECOMMENDED_MAX_EMBS_BOOL;
 
         // Note: _max_emb MUST be multiple of 64
@@ -531,10 +525,6 @@ namespace SUCMP_NM {
      */
     template<class TFloat, class TEmb>
     class UnifracVawTask : public UnifracTaskBase<TFloat,TEmb> {
-      protected:
-        // Use a moderate sized step, a few cache lines
-        static constexpr unsigned int step_size = 64*4/sizeof(TFloat);
-
       public:
         TFloat * const embedded_counts;
         const TFloat * const sample_total_counts;

--- a/src/unifrac_task.hpp
+++ b/src/unifrac_task.hpp
@@ -181,7 +181,9 @@ namespace SUCMP_NM {
 
         }
 
-        void compute_totals();
+        void compute_totals() {
+          compute_stripes_totals(this->dm_stripes.buf, this->dm_stripes_total.buf, this->dm_stripes.bufels);
+	}
 
         //
         // ===== Internal, do not use directly =======

--- a/src/unifrac_task.hpp
+++ b/src/unifrac_task.hpp
@@ -343,7 +343,16 @@ namespace SUCMP_NM {
 
         virtual void run(unsigned int filled_embs) {_run(filled_embs);}
 
-        void _run(unsigned int filled_embs);
+        void _run(unsigned int filled_embs) {
+           run_UnnormalizedWeightedTask(
+			  filled_embs,
+			  this->task_p->start, this->task_p->stop, this->task_p->n_samples, this->dm_stripes.n_samples_r,
+			  this->lengths,  this->get_embedded_proportions(), this->dm_stripes.buf,
+			  this->zcheck, this->sums);
+
+           // next iteration will use the alternative space
+           this->set_alt_embedded_proportions();
+	}
       protected:
         // temp buffers
         bool     *zcheck;

--- a/src/unifrac_task.hpp
+++ b/src/unifrac_task.hpp
@@ -128,7 +128,7 @@ namespace SUCMP_NM {
         {
             acc_create_buf(lengths,0,max_embs);
             acc_create_buf(my_embedded_proportions,0,embsize);
-            if (need_alt()) {
+            if (acc_need_alt()) {
                my_embedded_proportions_alt = (TEmb *) malloc(sizeof(TEmb)*embsize);
                acc_create_buf(my_embedded_proportions_alt,0,embsize);
             }
@@ -188,10 +188,6 @@ namespace SUCMP_NM {
         //
         // ===== Internal, do not use directly =======
         //
-
-	// is the implementation async, and need the alt structures?
-	static bool need_alt();
-
 
         // Just copy from one buffer to another
         // May convert between fp formats in the process (if TOut!=double)

--- a/src/unifrac_task_noclass.cpp
+++ b/src/unifrac_task_noclass.cpp
@@ -1,5 +1,6 @@
+#include <math.h> 
 #include <algorithm> 
-#include "unifrac_task.hpp"
+#include "unifrac_task_noclass.hpp"
 #include <cstdlib>
 
 #if defined(OMPGPU)
@@ -85,8 +86,7 @@ void SUCMP_NM::acc_destroy_buf(T *buf, uint64_t start, uint64_t end) {
 }
 
 // is the implementation async, and need the alt structures?
-template<class TFloat, class TEmb>
-bool SUCMP_NM::UnifracTaskBase<TFloat,TEmb>::need_alt() {
+bool SUCMP_NM::acc_need_alt() {
 #if defined(_OPENACC) || defined(OMPGPU)
    return true;
 #else

--- a/src/unifrac_task_noclass.cpp
+++ b/src/unifrac_task_noclass.cpp
@@ -525,10 +525,8 @@ static inline void UnnormalizedWeighted8(
 }
 #endif
 
-} // end namespace
-
 template<class TFloat>
-void SUCMP_NM::run_UnnormalizedWeightedTask(
+static inline void run_UnnormalizedWeightedTask_T(
 		const unsigned int filled_embs,
 		const uint64_t start_idx, const uint64_t stop_idx,
 		const uint64_t n_samples, const uint64_t n_samples_r,
@@ -632,7 +630,7 @@ void SUCMP_NM::run_UnnormalizedWeightedTask(
 }
 
 template<class TFloat>
-void SUCMP_NM::run_VawUnnormalizedWeightedTask(
+static inline void run_VawUnnormalizedWeightedTask_T(
 		const unsigned int filled_embs,
 		const uint64_t start_idx, const uint64_t stop_idx,
 		const uint64_t n_samples, const uint64_t n_samples_r,
@@ -699,8 +697,6 @@ void SUCMP_NM::run_VawUnnormalizedWeightedTask(
       }
     }
 }
-
-namespace SUCMP_NM {
 
 // Single step in computing NormalizedWeighted Unifrac
 template<class TFloat>
@@ -972,10 +968,8 @@ static inline void NormalizedWeighted8(
 }
 #endif
 
-} // end namespace
-
 template<class TFloat>
-void SUCMP_NM::run_NormalizedWeightedTask(
+static inline void run_NormalizedWeightedTask_T(
 		const unsigned int filled_embs,
 		const uint64_t start_idx, const uint64_t stop_idx,
 		const uint64_t n_samples, const uint64_t n_samples_r,
@@ -1080,7 +1074,7 @@ void SUCMP_NM::run_NormalizedWeightedTask(
 }
 
 template<class TFloat>
-void SUCMP_NM::run_VawNormalizedWeightedTask(
+static inline void run_VawNormalizedWeightedTask_T(
 		const unsigned int filled_embs,
 		const uint64_t start_idx, const uint64_t stop_idx,
 		const uint64_t n_samples, const uint64_t n_samples_r,
@@ -1156,7 +1150,7 @@ void SUCMP_NM::run_VawNormalizedWeightedTask(
 }
 
 template<class TFloat>
-void SUCMP_NM::run_GeneralizedTask(
+static inline void run_GeneralizedTask_T(
 		const unsigned int filled_embs,
 		const uint64_t start_idx, const uint64_t stop_idx,
 		const uint64_t n_samples, const uint64_t n_samples_r,
@@ -1229,7 +1223,7 @@ void SUCMP_NM::run_GeneralizedTask(
 }
 
 template<class TFloat>
-void SUCMP_NM::run_VawGeneralizedTask(
+static inline void run_VawGeneralizedTask_T(
 		const unsigned int filled_embs,
 		const uint64_t start_idx, const uint64_t stop_idx, const uint64_t n_samples, const uint64_t n_samples_r,
 		const TFloat * const __restrict__ lengths,
@@ -1640,7 +1634,7 @@ static inline void UnweightedZerosAndSums(
 }
 
 template<class TFloat>
-void SUCMP_NM::run_UnweightedTask(
+static inline void run_UnweightedTask_T(
 		const unsigned int filled_embs,
 		const uint64_t start_idx, const uint64_t stop_idx,
 		const uint64_t n_samples, const uint64_t n_samples_r,
@@ -1801,7 +1795,7 @@ void SUCMP_NM::run_UnweightedTask(
 }
 
 template<class TFloat>
-void SUCMP_NM::run_UnnormalizedUnweightedTask(
+static inline void run_UnnormalizedUnweightedTask_T(
 		const unsigned int filled_embs,
 		const uint64_t start_idx, const uint64_t stop_idx,
 		const uint64_t n_samples, const uint64_t n_samples_r,
@@ -1961,7 +1955,7 @@ void SUCMP_NM::run_UnnormalizedUnweightedTask(
 }
 
 template<class TFloat>
-void SUCMP_NM::run_VawUnweightedTask(
+static inline void run_VawUnweightedTask_T(
 		const unsigned int filled_embs,
 		const uint64_t start_idx, const uint64_t stop_idx,
 		const uint64_t n_samples, const uint64_t n_samples_r,
@@ -2054,7 +2048,7 @@ void SUCMP_NM::run_VawUnweightedTask(
 }
 
 template<class TFloat>
-void SUCMP_NM::run_VawUnnormalizedUnweightedTask(
+static inline void run_VawUnnormalizedUnweightedTask_T(
 		const unsigned int filled_embs,
 		const uint64_t start_idx, const uint64_t stop_idx,
 		const uint64_t n_samples, const uint64_t n_samples_r,
@@ -2139,6 +2133,8 @@ void SUCMP_NM::run_VawUnnormalizedUnweightedTask(
     }
 }
 
+} // end namespace
+
 /*
  * Create concrete implementation wrappers
  */
@@ -2164,6 +2160,8 @@ void SUCMP_NM::acc_create_buf(bool *buf, uint64_t start, uint64_t end) {
    acc_create_buf_T(buf, start, end);
 }
 
+// ==================================
+
 template<>
 void SUCMP_NM::acc_copyin_buf(float *buf, uint64_t start, uint64_t end) {
    acc_copyin_buf_T(buf, start, end);
@@ -2180,6 +2178,8 @@ template<>
 void SUCMP_NM::acc_copyin_buf(uint32_t *buf, uint64_t start, uint64_t end) {
    acc_copyin_buf_T(buf, start, end);
 }
+
+// ==================================
 
 template<>
 void SUCMP_NM::acc_update_device(float *buf, uint64_t start, uint64_t end) {
@@ -2198,6 +2198,8 @@ void SUCMP_NM::acc_update_device(uint64_t *buf, uint64_t start, uint64_t end) {
    acc_update_device_T(buf, start, end);
 }
 
+// ==================================
+
 template<>
 void SUCMP_NM::acc_copyout_buf(float *buf, uint64_t start, uint64_t end) {
    acc_copyout_buf_T(buf, start, end);
@@ -2206,6 +2208,8 @@ template<>
 void SUCMP_NM::acc_copyout_buf(double *buf, uint64_t start, uint64_t end) {
    acc_copyout_buf_T(buf, start, end);
 }
+
+// ==================================
 
 template<>
 void SUCMP_NM::acc_destroy_buf(float *buf, uint64_t start, uint64_t end) {
@@ -2228,6 +2232,8 @@ void SUCMP_NM::acc_destroy_buf(bool *buf, uint64_t start, uint64_t end) {
    acc_destroy_buf_T(buf, start, end);
 }
 
+// ==================================
+
 template<>
 void SUCMP_NM::compute_stripes_totals(
 		float * const __restrict__ dm_stripes_buf,
@@ -2242,5 +2248,393 @@ void SUCMP_NM::compute_stripes_totals(
 		const double * const __restrict__ dm_stripes_total_buf,
 		const uint64_t bufels) {
    compute_stripes_totals_T(dm_stripes_buf, dm_stripes_total_buf, bufels);
+}
+
+// ==================================
+
+template<>
+void SUCMP_NM::run_UnnormalizedWeightedTask(
+		const unsigned int filled_embs,
+		const uint64_t start_idx, const uint64_t stop_idx,
+		const uint64_t n_samples, const uint64_t n_samples_r,
+		const float * const __restrict__ lengths,
+		const float * const __restrict__ embedded_proportions,
+		float * const __restrict__ dm_stripes_buf,
+		bool * const __restrict__ zcheck,
+		float * const __restrict__ sums) {
+   run_UnnormalizedWeightedTask_T(
+		   filled_embs,
+		   start_idx, stop_idx, n_samples, n_samples_r,
+		   lengths, embedded_proportions,
+		   dm_stripes_buf,
+		   zcheck, sums);
+}
+
+template<>
+void SUCMP_NM::run_UnnormalizedWeightedTask(
+		const unsigned int filled_embs,
+		const uint64_t start_idx, const uint64_t stop_idx,
+		const uint64_t n_samples, const uint64_t n_samples_r,
+		const double * const __restrict__ lengths,
+		const double * const __restrict__ embedded_proportions,
+		double * const __restrict__ dm_stripes_buf,
+		bool * const __restrict__ zcheck,
+		double * const __restrict__ sums) {
+   run_UnnormalizedWeightedTask_T(
+		   filled_embs,
+		   start_idx, stop_idx, n_samples, n_samples_r,
+		   lengths, embedded_proportions,
+		   dm_stripes_buf,
+		   zcheck, sums);
+}
+
+// ==================================
+
+template<>
+void SUCMP_NM::run_VawUnnormalizedWeightedTask(
+		const unsigned int filled_embs,
+		const uint64_t start_idx, const uint64_t stop_idx,
+		const uint64_t n_samples, const uint64_t n_samples_r,
+		const float * const __restrict__ lengths,
+		const float * const __restrict__ embedded_proportions,
+		const float * const __restrict__ embedded_counts,
+		const float * const __restrict__ sample_total_counts,
+		float * const __restrict__ dm_stripes_buf) {
+   run_VawUnnormalizedWeightedTask_T(
+		   filled_embs,
+		   start_idx, stop_idx, n_samples, n_samples_r,
+		   lengths, embedded_proportions, embedded_counts, sample_total_counts,
+		   dm_stripes_buf);
+}
+
+template<>
+void SUCMP_NM::run_VawUnnormalizedWeightedTask(
+		const unsigned int filled_embs,
+		const uint64_t start_idx, const uint64_t stop_idx,
+		const uint64_t n_samples, const uint64_t n_samples_r,
+		const double * const __restrict__ lengths,
+		const double * const __restrict__ embedded_proportions,
+		const double * const __restrict__ embedded_counts,
+		const double * const __restrict__ sample_total_counts,
+		double * const __restrict__ dm_stripes_buf) {
+   run_VawUnnormalizedWeightedTask_T(
+		   filled_embs,
+		   start_idx, stop_idx, n_samples, n_samples_r,
+		   lengths, embedded_proportions, embedded_counts, sample_total_counts,
+		   dm_stripes_buf);
+}
+
+// ==================================
+
+template<>
+void SUCMP_NM::run_NormalizedWeightedTask(
+		const unsigned int filled_embs,
+		const uint64_t start_idx, const uint64_t stop_idx,
+		const uint64_t n_samples, const uint64_t n_samples_r,
+		const float * const __restrict__ lengths,
+		const float * const __restrict__ embedded_proportions,
+		float * const __restrict__ dm_stripes_buf,
+		float * const __restrict__ dm_stripes_total_buf,
+		bool * const __restrict__ zcheck,
+		float * const __restrict__ sums) {
+   run_NormalizedWeightedTask_T(
+		   filled_embs,
+                   start_idx, stop_idx, n_samples, n_samples_r,
+		   lengths, embedded_proportions,
+		   dm_stripes_buf, dm_stripes_total_buf,
+		   zcheck, sums);
+}
+
+template<>
+void SUCMP_NM::run_NormalizedWeightedTask(
+		const unsigned int filled_embs,
+		const uint64_t start_idx, const uint64_t stop_idx,
+		const uint64_t n_samples, const uint64_t n_samples_r,
+		const double * const __restrict__ lengths,
+		const double * const __restrict__ embedded_proportions,
+		double * const __restrict__ dm_stripes_buf,
+		double * const __restrict__ dm_stripes_total_buf,
+		bool * const __restrict__ zcheck,
+		double * const __restrict__ sums) {
+   run_NormalizedWeightedTask_T(
+		   filled_embs,
+                   start_idx, stop_idx, n_samples, n_samples_r,
+		   lengths, embedded_proportions,
+		   dm_stripes_buf, dm_stripes_total_buf,
+		   zcheck, sums);
+}
+
+// ==================================
+
+template<>
+void SUCMP_NM::run_VawNormalizedWeightedTask(
+		const unsigned int filled_embs,
+		const uint64_t start_idx, const uint64_t stop_idx,
+		const uint64_t n_samples, const uint64_t n_samples_r,
+		const float * const __restrict__ lengths,
+		const float * const __restrict__ embedded_proportions,
+		const float * const __restrict__ embedded_counts,
+		const float * const __restrict__ sample_total_counts,
+		float * const __restrict__ dm_stripes_buf,
+		float * const __restrict__ dm_stripes_total_buf) {
+   run_VawNormalizedWeightedTask_T(
+		   filled_embs,
+                   start_idx, stop_idx, n_samples, n_samples_r,
+		   lengths, embedded_proportions, embedded_counts, sample_total_counts,
+		   dm_stripes_buf, dm_stripes_total_buf);
+}
+
+template<>
+void SUCMP_NM::run_VawNormalizedWeightedTask(
+		const unsigned int filled_embs,
+		const uint64_t start_idx, const uint64_t stop_idx,
+		const uint64_t n_samples, const uint64_t n_samples_r,
+		const double * const __restrict__ lengths,
+		const double * const __restrict__ embedded_proportions,
+		const double * const __restrict__ embedded_counts,
+		const double * const __restrict__ sample_total_counts,
+		double * const __restrict__ dm_stripes_buf,
+		double * const __restrict__ dm_stripes_total_buf) {
+   run_VawNormalizedWeightedTask_T(
+		   filled_embs,
+                   start_idx, stop_idx, n_samples, n_samples_r,
+		   lengths, embedded_proportions, embedded_counts, sample_total_counts,
+		   dm_stripes_buf, dm_stripes_total_buf);
+}
+
+// ==================================
+
+template<>
+void SUCMP_NM::run_GeneralizedTask(
+		const unsigned int filled_embs,
+		const uint64_t start_idx, const uint64_t stop_idx,
+		const uint64_t n_samples, const uint64_t n_samples_r,
+		const float * const __restrict__ lengths,
+		const float * const __restrict__ embedded_proportions,
+		float * const __restrict__ dm_stripes_buf,
+		float * const __restrict__ dm_stripes_total_buf,
+		const float g_unifrac_alpha) {
+   run_GeneralizedTask_T(
+		   filled_embs,
+                   start_idx, stop_idx, n_samples, n_samples_r,
+		   lengths, embedded_proportions,
+		   dm_stripes_buf, dm_stripes_total_buf,
+		   g_unifrac_alpha);
+}
+
+template<>
+void SUCMP_NM::run_GeneralizedTask(
+		const unsigned int filled_embs,
+		const uint64_t start_idx, const uint64_t stop_idx,
+		const uint64_t n_samples, const uint64_t n_samples_r,
+		const double * const __restrict__ lengths,
+		const double * const __restrict__ embedded_proportions,
+		double * const __restrict__ dm_stripes_buf,
+		double * const __restrict__ dm_stripes_total_buf,
+		const double g_unifrac_alpha) {
+   run_GeneralizedTask_T(
+		   filled_embs,
+                   start_idx, stop_idx, n_samples, n_samples_r,
+		   lengths, embedded_proportions,
+		   dm_stripes_buf, dm_stripes_total_buf,
+		   g_unifrac_alpha);
+}
+
+// ==================================
+
+template<>
+void SUCMP_NM::run_VawGeneralizedTask(
+		const unsigned int filled_embs,
+		const uint64_t start_idx, const uint64_t stop_idx,
+		const uint64_t n_samples, const uint64_t n_samples_r,
+		const float * const __restrict__ lengths,
+		const float * const __restrict__ embedded_proportions,
+		const float * const __restrict__ embedded_counts,
+		const float * const __restrict__ sample_total_counts ,
+		float * const __restrict__ dm_stripes_buf,
+		float * const __restrict__ dm_stripes_total_buf,
+		const float g_unifrac_alpha) {
+   run_VawGeneralizedTask_T(
+		   filled_embs,
+                   start_idx, stop_idx, n_samples, n_samples_r,
+		   lengths, embedded_proportions, embedded_counts, sample_total_counts,
+		   dm_stripes_buf, dm_stripes_total_buf,
+		   g_unifrac_alpha);
+}
+
+template<>
+void SUCMP_NM::run_VawGeneralizedTask(
+		const unsigned int filled_embs,
+		const uint64_t start_idx, const uint64_t stop_idx,
+		const uint64_t n_samples, const uint64_t n_samples_r,
+		const double * const __restrict__ lengths,
+		const double * const __restrict__ embedded_proportions,
+		const double * const __restrict__ embedded_counts,
+		const double * const __restrict__ sample_total_counts ,
+		double * const __restrict__ dm_stripes_buf,
+		double * const __restrict__ dm_stripes_total_buf,
+		const double g_unifrac_alpha) {
+   run_VawGeneralizedTask_T(
+		   filled_embs,
+                   start_idx, stop_idx, n_samples, n_samples_r,
+		   lengths, embedded_proportions, embedded_counts, sample_total_counts,
+		   dm_stripes_buf, dm_stripes_total_buf,
+		   g_unifrac_alpha);
+}
+
+// ==================================
+
+template<>
+void SUCMP_NM::run_UnweightedTask(
+		const unsigned int filled_embs,
+		const uint64_t start_idx, const uint64_t stop_idx,
+		const uint64_t n_samples, const uint64_t n_samples_r,
+		const float * const __restrict__ lengths,
+		const uint64_t * const __restrict__ embedded_proportions,
+		float * const __restrict__ dm_stripes_buf,
+		float * const __restrict__ dm_stripes_total_buf,
+		float * const __restrict__ sums,
+		bool   * const __restrict__ zcheck,
+		float * const __restrict__ stripe_sums) {
+   run_UnweightedTask_T(
+		   filled_embs,
+                   start_idx, stop_idx, n_samples, n_samples_r,
+		   lengths, embedded_proportions,
+		   dm_stripes_buf, dm_stripes_total_buf,
+		   sums, zcheck, stripe_sums);
+}
+
+template<>
+void SUCMP_NM::run_UnweightedTask(
+		const unsigned int filled_embs,
+		const uint64_t start_idx, const uint64_t stop_idx,
+		const uint64_t n_samples, const uint64_t n_samples_r,
+		const double * const __restrict__ lengths,
+		const uint64_t * const __restrict__ embedded_proportions,
+		double * const __restrict__ dm_stripes_buf,
+		double * const __restrict__ dm_stripes_total_buf,
+		double * const __restrict__ sums,
+		bool   * const __restrict__ zcheck,
+		double * const __restrict__ stripe_sums) {
+   run_UnweightedTask_T(
+		   filled_embs,
+                   start_idx, stop_idx, n_samples, n_samples_r,
+		   lengths, embedded_proportions,
+		   dm_stripes_buf, dm_stripes_total_buf,
+		   sums, zcheck, stripe_sums);
+}
+
+// ==================================
+
+template<>
+void SUCMP_NM::run_UnnormalizedUnweightedTask(
+		const unsigned int filled_embs,
+		const uint64_t start_idx, const uint64_t stop_idx,
+		const uint64_t n_samples, const uint64_t n_samples_r,
+		const float * const __restrict__ lengths,
+		const uint64_t * const __restrict__ embedded_proportions,
+		float * const __restrict__ dm_stripes_buf,
+		float * const __restrict__ sums,
+		bool   * const __restrict__ zcheck,
+		float * const __restrict__ stripe_sums) {
+   run_UnnormalizedUnweightedTask_T(
+		   filled_embs,
+                   start_idx, stop_idx, n_samples, n_samples_r,
+		   lengths, embedded_proportions,
+		   dm_stripes_buf,
+		   sums, zcheck, stripe_sums);
+}
+
+template<>
+void SUCMP_NM::run_UnnormalizedUnweightedTask(
+		const unsigned int filled_embs,
+		const uint64_t start_idx, const uint64_t stop_idx,
+		const uint64_t n_samples, const uint64_t n_samples_r,
+		const double * const __restrict__ lengths,
+		const uint64_t * const __restrict__ embedded_proportions,
+		double * const __restrict__ dm_stripes_buf,
+		double * const __restrict__ sums,
+		bool   * const __restrict__ zcheck,
+		double * const __restrict__ stripe_sums) {
+   run_UnnormalizedUnweightedTask_T(
+		   filled_embs,
+                   start_idx, stop_idx, n_samples, n_samples_r,
+		   lengths, embedded_proportions,
+		   dm_stripes_buf,
+		   sums, zcheck, stripe_sums);
+}
+
+// ==================================
+
+template<>
+void SUCMP_NM::run_VawUnweightedTask(
+		const unsigned int filled_embs,
+		const uint64_t start_idx, const uint64_t stop_idx,
+		const uint64_t n_samples, const uint64_t n_samples_r,
+		const float * const __restrict__ lengths,
+		const uint32_t * const __restrict__ embedded_proportions,
+		const float  * const __restrict__ embedded_counts,
+		const float  * const __restrict__ sample_total_counts,
+		float * const __restrict__ dm_stripes_buf,
+		float * const __restrict__ dm_stripes_total_buf) {
+   run_VawUnweightedTask_T(
+		   filled_embs,
+                   start_idx, stop_idx, n_samples, n_samples_r,
+		   lengths, embedded_proportions, embedded_counts, sample_total_counts,
+		   dm_stripes_buf, dm_stripes_total_buf);
+}
+
+template<>
+void SUCMP_NM::run_VawUnweightedTask(
+		const unsigned int filled_embs,
+		const uint64_t start_idx, const uint64_t stop_idx,
+		const uint64_t n_samples, const uint64_t n_samples_r,
+		const double * const __restrict__ lengths,
+		const uint32_t * const __restrict__ embedded_proportions,
+		const double  * const __restrict__ embedded_counts,
+		const double  * const __restrict__ sample_total_counts,
+		double * const __restrict__ dm_stripes_buf,
+		double * const __restrict__ dm_stripes_total_buf) {
+   run_VawUnweightedTask_T(
+		   filled_embs,
+                   start_idx, stop_idx, n_samples, n_samples_r,
+		   lengths, embedded_proportions, embedded_counts, sample_total_counts,
+		   dm_stripes_buf, dm_stripes_total_buf);
+}
+
+// ==================================
+
+template<>
+void SUCMP_NM::run_VawUnnormalizedUnweightedTask(
+		const unsigned int filled_embs,
+		const uint64_t start_idx, const uint64_t stop_idx,
+		const uint64_t n_samples, const uint64_t n_samples_r,
+		const float * const __restrict__ lengths,
+		const uint32_t * const __restrict__ embedded_proportions,
+		const float  * const __restrict__ embedded_counts,
+		const float  * const __restrict__ sample_total_counts,
+		float * const __restrict__ dm_stripes_buf) {
+   run_VawUnnormalizedUnweightedTask_T(
+		   filled_embs,
+                   start_idx, stop_idx, n_samples, n_samples_r,
+		   lengths, embedded_proportions, embedded_counts, sample_total_counts,
+		   dm_stripes_buf);
+}
+
+template<>
+void SUCMP_NM::run_VawUnnormalizedUnweightedTask(
+		const unsigned int filled_embs,
+		const uint64_t start_idx, const uint64_t stop_idx,
+		const uint64_t n_samples, const uint64_t n_samples_r,
+		const double * const __restrict__ lengths,
+		const uint32_t * const __restrict__ embedded_proportions,
+		const double  * const __restrict__ embedded_counts,
+		const double  * const __restrict__ sample_total_counts,
+		double * const __restrict__ dm_stripes_buf) {
+   run_VawUnnormalizedUnweightedTask_T(
+		   filled_embs,
+                   start_idx, stop_idx, n_samples, n_samples_r,
+		   lengths, embedded_proportions, embedded_counts, sample_total_counts,
+		   dm_stripes_buf);
 }
 

--- a/src/unifrac_task_noclass.cpp
+++ b/src/unifrac_task_noclass.cpp
@@ -22,7 +22,7 @@
 // Use a moderate sized step, a few cache lines
 #define STEP_SIZE(TFloat) (64*4/sizeof(TFloat))
 
-bool SUCMP_NM::found_gpu() {
+bool SUCMP_NM::acc_found_gpu() {
 #if defined(OMPGPU)
   return omp_get_num_devices() > 0;
 #elif defined(_OPENACC)

--- a/src/unifrac_task_noclass.hpp
+++ b/src/unifrac_task_noclass.hpp
@@ -44,11 +44,25 @@ namespace SUCMP_NM {
     template<class T>
     void acc_destroy_buf(T *buf, uint64_t start, uint64_t end);
 
+    // compute totals
     template<class TFloat>
     void compute_stripes_totals(
 		TFloat * const __restrict__ dm_stripes_buf,
 		const TFloat * const __restrict__ dm_stripes_total_buf,
 		const uint64_t bufels);
+
+    // Compute UnnormalizedWeighted step
+    template<class TFloat>
+    void run_UnnormalizedWeightedTask(
+		const unsigned int filled_embs,
+		const uint64_t start_idx, const uint64_t stop_idx,
+		const uint64_t n_samples, const uint64_t n_samples_r,
+		const TFloat * const __restrict__ lengths,
+		const TFloat * const __restrict__ embedded_proportions,
+		TFloat * const __restrict__ dm_stripes_buf,
+		bool * const __restrict__ zcheck,
+		TFloat * const __restrict__ sums);
+
 }
 
 #endif

--- a/src/unifrac_task_noclass.hpp
+++ b/src/unifrac_task_noclass.hpp
@@ -63,6 +63,43 @@ namespace SUCMP_NM {
 		bool * const __restrict__ zcheck,
 		TFloat * const __restrict__ sums);
 
+    // Compute NormalizedWeighted step
+    template<class TFloat>
+    void run_NormalizedWeightedTask(
+		const unsigned int filled_embs,
+		const uint64_t start_idx, const uint64_t stop_idx,
+		const uint64_t n_samples, const uint64_t n_samples_r,
+		const TFloat * const __restrict__ lengths,
+		const TFloat * const __restrict__ embedded_proportions,
+		TFloat * const __restrict__ dm_stripes_buf,
+		TFloat * const __restrict__ dm_stripes_total_buf,
+		bool * const __restrict__ zcheck,
+		TFloat * const __restrict__ sums);
+
+    // Compute VawUnnormalizedWeighted step
+    template<class TFloat>
+    void run_VawUnnormalizedWeightedTask(
+		const unsigned int filled_embs,
+		const uint64_t start_idx, const uint64_t stop_idx,
+		const uint64_t n_samples, const uint64_t n_samples_r,
+		const TFloat * const __restrict__ lengths,
+		const TFloat * const __restrict__ embedded_proportions,
+		const TFloat * const __restrict__ embedded_counts,
+		const TFloat * const __restrict__ sample_total_counts,
+		TFloat * const __restrict__ dm_stripes_buf);
+
+    // Compute VawNormalizedWeighted step
+    template<class TFloat>
+    void run_VawNormalizedWeightedTask(
+		const unsigned int filled_embs,
+		const uint64_t start_idx, const uint64_t stop_idx,
+		const uint64_t n_samples, const uint64_t n_samples_r,
+		const TFloat * const __restrict__ lengths,
+		const TFloat * const __restrict__ embedded_proportions,
+		const TFloat * const __restrict__ embedded_counts,
+		const TFloat * const __restrict__ sample_total_counts,
+		TFloat * const __restrict__ dm_stripes_buf,
+		TFloat * const __restrict__ dm_stripes_total_buf);
 }
 
 #endif

--- a/src/unifrac_task_noclass.hpp
+++ b/src/unifrac_task_noclass.hpp
@@ -16,7 +16,7 @@
 namespace SUCMP_NM {
 
     // do we have access to a GPU?
-    bool found_gpu();
+    bool acc_found_gpu();
 
     // is the implementation async, and need the alt structures?
     bool acc_need_alt();

--- a/src/unifrac_task_noclass.hpp
+++ b/src/unifrac_task_noclass.hpp
@@ -13,6 +13,11 @@
 
 #include <stdint.h>
 
+#ifndef SUCMP_NM
+/* create a default */
+#define SUCMP_NM su_cpu
+#endif
+
 namespace SUCMP_NM {
 
     // do we have access to a GPU?

--- a/src/unifrac_task_noclass.hpp
+++ b/src/unifrac_task_noclass.hpp
@@ -44,6 +44,11 @@ namespace SUCMP_NM {
     template<class T>
     void acc_destroy_buf(T *buf, uint64_t start, uint64_t end);
 
+    template<class TFloat>
+    void compute_stripes_totals(
+		TFloat * const __restrict__ dm_stripes_buf,
+		const TFloat * const __restrict__ dm_stripes_total_buf,
+		const uint64_t bufels);
 }
 
 #endif

--- a/src/unifrac_task_noclass.hpp
+++ b/src/unifrac_task_noclass.hpp
@@ -54,6 +54,21 @@ namespace SUCMP_NM {
 		const TFloat * const __restrict__ dm_stripes_total_buf,
 		const uint64_t bufels);
 
+    /* Unifrac tasks
+     *
+     * All functions utilize the same basic data structures:
+     *
+     * dm_stripes vector<double> the stripes of the distance matrix being accumulated 
+     *      into for unique branch length
+     * dm_stripes vector<double> the stripes of the distance matrix being accumulated 
+     *      into for total branch length (e.g., to normalize unweighted unifrac)
+     * embedded_proportions <double*> the proportions vector for a sample, or rather
+     *      the counts vector normalized to 1. this vector is embedded as it is 
+     *      duplicated: if A, B and C are proportions for features A, B, and C, the
+     *      vector will look like [A B C A B C].
+     * length <double> the branch length of the current node to its parent.
+     */
+
     // Compute UnnormalizedWeighted step
     template<class TFloat>
     void run_UnnormalizedWeightedTask(
@@ -117,6 +132,26 @@ namespace SUCMP_NM {
 		TFloat * const __restrict__ dm_stripes_buf,
 		TFloat * const __restrict__ dm_stripes_total_buf,
 		const TFloat g_unifrac_alpha);
+
+    /* Unifrac vaw tasks
+     *
+     * All functions utilize the same basic data structures:
+     *
+     * dm_stripes vector<double> the stripes of the distance matrix being accumulated 
+     *      into for unique branch length
+     * dm_stripes vector<double> the stripes of the distance matrix being accumulated 
+     *      into for total branch length (e.g., to normalize unweighted unifrac)
+     * embedded_proportions <double*> the proportions vector for a sample, or rather
+     *      the counts vector normalized to 1. this vector is embedded as it is 
+     *      duplicated: if A, B and C are proportions for features A, B, and C, the
+     *      vector will look like [A B C A B C].
+     * embedded_counts <double*> the counts vector embedded in the same way and order as
+     *      embedded_proportions. the values of this array are unnormalized feature 
+     *      counts for the subtree.
+     * sample_total_counts <double*> the total unnormalized feature counts for all samples
+     *      embedded in the same way and order as embedded_proportions.
+     * length <double> the branch length of the current node to its parent.
+     */
 
     // Compute VawUnnormalizedWeighted step
     template<class TFloat>

--- a/src/unifrac_task_noclass.hpp
+++ b/src/unifrac_task_noclass.hpp
@@ -1,0 +1,49 @@
+/*
+ * BSD 3-Clause License
+ *
+ * Copyright (c) 2025-2025, UniFrac development team.
+ * All rights reserved.
+ *
+ * See LICENSE file for more details
+ */
+
+
+#ifndef __UNIFRAC_TASK_NOCLASS
+#define __UNIFRAC_TASK_NOCLASS 1
+
+#include <stdint.h>
+
+namespace SUCMP_NM {
+
+    // do we have access to a GPU?
+    bool found_gpu();
+
+    // wait for the async compute to finish
+    void acc_wait();
+
+    // create the equivalent buffer in the device memory space, if partitioned
+    // the content in undefined
+    template<class T>
+    void acc_create_buf(T *buf, uint64_t start, uint64_t end);
+
+    // create the equivalent buffer in the device memory space, if partitioned
+    // also copy the buffer over
+    template<class T>
+    void acc_copyin_buf(T *buf, uint64_t start, uint64_t end);
+
+    // make a copy from host to device buffer, if partitioned
+    template<class T>
+    void acc_update_device(T *buf, uint64_t start, uint64_t end);
+
+    // make a copy from device to host buffer, if partitioned
+    // destroy the equivalent buffer in the device memory space, if partitioned
+    template<class T>
+    void acc_copyout_buf(T *buf, uint64_t start, uint64_t end);
+
+    // destroy the equivalent buffer in the device memory space, if partitioned
+    template<class T>
+    void acc_destroy_buf(T *buf, uint64_t start, uint64_t end);
+
+}
+
+#endif

--- a/src/unifrac_task_noclass.hpp
+++ b/src/unifrac_task_noclass.hpp
@@ -18,6 +18,9 @@ namespace SUCMP_NM {
     // do we have access to a GPU?
     bool found_gpu();
 
+    // is the implementation async, and need the alt structures?
+    bool acc_need_alt();
+
     // wait for the async compute to finish
     void acc_wait();
 

--- a/src/unifrac_task_noclass.hpp
+++ b/src/unifrac_task_noclass.hpp
@@ -76,6 +76,45 @@ namespace SUCMP_NM {
 		bool * const __restrict__ zcheck,
 		TFloat * const __restrict__ sums);
 
+    // Compute Unweighted step
+    template<class TFloat>
+    void run_UnweightedTask(
+		const unsigned int filled_embs,
+		const uint64_t start_idx, const uint64_t stop_idx,
+		const uint64_t n_samples, const uint64_t n_samples_r,
+		const TFloat * const __restrict__ lengths,
+		const uint64_t * const __restrict__ embedded_proportions,
+		TFloat * const __restrict__ dm_stripes_buf,
+		TFloat * const __restrict__ dm_stripes_total_buf,
+		TFloat * const __restrict__ sums,
+		bool   * const __restrict__ zcheck,
+		TFloat * const __restrict__ stripe_sums);
+
+    // Compute UnnormalizedUnweighted step
+    template<class TFloat>
+    void run_UnnormalizedUnweightedTask(
+		const unsigned int filled_embs,
+		const uint64_t start_idx, const uint64_t stop_idx,
+		const uint64_t n_samples, const uint64_t n_samples_r,
+		const TFloat * const __restrict__ lengths,
+		const uint64_t * const __restrict__ embedded_proportions,
+		TFloat * const __restrict__ dm_stripes_buf,
+		TFloat * const __restrict__ sums,
+		bool   * const __restrict__ zcheck,
+		TFloat * const __restrict__ stripe_sums);
+
+    // Compute Generalized step
+    template<class TFloat>
+    void run_GeneralizedTask(
+		const unsigned int filled_embs,
+		const uint64_t start_idx, const uint64_t stop_idx,
+		const uint64_t n_samples, const uint64_t n_samples_r,
+		const TFloat * const __restrict__ lengths,
+		const TFloat * const __restrict__ embedded_proportions,
+		TFloat * const __restrict__ dm_stripes_buf,
+		TFloat * const __restrict__ dm_stripes_total_buf,
+		const TFloat g_unifrac_alpha);
+
     // Compute VawUnnormalizedWeighted step
     template<class TFloat>
     void run_VawUnnormalizedWeightedTask(
@@ -100,6 +139,44 @@ namespace SUCMP_NM {
 		const TFloat * const __restrict__ sample_total_counts,
 		TFloat * const __restrict__ dm_stripes_buf,
 		TFloat * const __restrict__ dm_stripes_total_buf);
+
+    // Compute VawUnweighted step
+    template<class TFloat>
+    void run_VawUnweightedTask(
+		const unsigned int filled_embs,
+		const uint64_t start_idx, const uint64_t stop_idx,
+		const uint64_t n_samples, const uint64_t n_samples_r,
+		const TFloat * const __restrict__ lengths,
+		const uint32_t * const __restrict__ embedded_proportions,
+		const TFloat  * const __restrict__ embedded_counts,
+		const TFloat  * const __restrict__ sample_total_counts,
+		TFloat * const __restrict__ dm_stripes_buf,
+		TFloat * const __restrict__ dm_stripes_total_buf);
+
+    // Compute VawUnnormalizedUnweighted step
+    template<class TFloat>
+    void run_VawUnnormalizedUnweightedTask(
+		const unsigned int filled_embs,
+		const uint64_t start_idx, const uint64_t stop_idx,
+		const uint64_t n_samples, const uint64_t n_samples_r,
+		const TFloat * const __restrict__ lengths,
+		const uint32_t * const __restrict__ embedded_proportions,
+		const TFloat  * const __restrict__ embedded_counts,
+		const TFloat  * const __restrict__ sample_total_counts,
+		TFloat * const __restrict__ dm_stripes_buf);
+
+    // Compute Generalized step
+    template<class TFloat>
+    void run_VawGeneralizedTask(
+		const unsigned int filled_embs,
+		const uint64_t start_idx, const uint64_t stop_idx, const uint64_t n_samples, const uint64_t n_samples_r,
+		const TFloat * const __restrict__ lengths,
+		const TFloat * const __restrict__ embedded_proportions,
+		const TFloat * const __restrict__ embedded_counts,
+		const TFloat * const __restrict__ sample_total_counts ,
+		TFloat * const __restrict__ dm_stripes_buf,
+		TFloat * const __restrict__ dm_stripes_total_buf,
+		const TFloat g_unifrac_alpha);
 }
 
 #endif


### PR DESCRIPTION
The accelerated code was included in a unifrac_cmp before, mixing CPU-only OMP and acc code paths.
Now it it clearly separated.