### PR TITLE
Add support for both NVIDIA and AMD GPUs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -100,6 +100,7 @@ jobs:
         ./test_su
         ./test_api
         ./test_ska
+        ./test_su_api
         popd
         pushd test
         ./capi_test 1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,7 +80,7 @@ jobs:
         env
         echo "=======  end env  ====="
         # all == build (shlib,bins,tests) and install
-        make all
+        make clean && make_clean_install && make all
         df -h .
     - name: Tests
       shell: bash -l {0}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,10 +68,13 @@ jobs:
         then
           # install PGI locally
           ./scripts/install_hpc_sdk.sh </dev/null
-          # get the PGI compilers in the path and set NV_CXX
+          # also install the AMD compiler
+          ./scripts/install_amd_clang.sh </dev/null
+          # get the compilers in the path and set NV_CXX and AMD_CXX
           . ./setup_nv_compiler.sh
+          . ./setup_amd_compiler.sh
         fi
-        # else, no NV_CXX in the env, so no GPU build
+        # else, no NV_CXX or AMD_CXX in the env, so no GPU build
         df -h .
         echo "======= begin env ====="
         env

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,8 +66,6 @@ jobs:
         export BUILD_NV_OFFLOAD=${{ matrix.offload }}
         if [[ "$(uname -s)" == "Linux" ]] && [[ "x${BUILD_NV_OFFLOAD}" != "xcpu" ]];
         then
-          # Note: Not checking for errors, as GPU compilers are optional (check build logs by hand)
-
           # install PGI locally
           ./scripts/install_hpc_sdk.sh </dev/null
           # also install the AMD compiler

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,6 +66,8 @@ jobs:
         export BUILD_NV_OFFLOAD=${{ matrix.offload }}
         if [[ "$(uname -s)" == "Linux" ]] && [[ "x${BUILD_NV_OFFLOAD}" != "xcpu" ]];
         then
+          # Note: Not checking for errors, as GPU compilers are optional (check build logs by hand)
+
           # install PGI locally
           ./scripts/install_hpc_sdk.sh </dev/null
           # also install the AMD compiler

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,20 +63,16 @@ jobs:
         fi
         which h5c++
         export PERFORMING_CONDA_BUILD=True
-        export BUILD_OFFLOAD=${{ matrix.offload }}
-        if [[ "$(uname -s)" == "Linux" ]] && [[ "x${BUILD_OFFLOAD}" != "xcpu" ]];
+        export BUILD_NV_OFFLOAD=${{ matrix.offload }}
+        if [[ "$(uname -s)" == "Linux" ]] && [[ "x${BUILD_NV_OFFLOAD}" != "xcpu" ]];
         then
           # install PGI locally
           ./scripts/install_hpc_sdk.sh </dev/null
           # get the PGI compilers in the path and set NV_CXX
           . ./setup_nv_compiler.sh
         fi
+        # else, no NV_CXX in the env, so no GPU build
         df -h .
-        if [[ "x${BUILD_OFFLOAD}" == "xcpu" ]];
-        then
-           # CPU-only builds use no GPU
-           export NOGPU=1
-        fi
         echo "======= begin env ====="
         env
         echo "=======  end env  ====="

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,9 +66,10 @@ jobs:
         export BUILD_OFFLOAD=${{ matrix.offload }}
         if [[ "$(uname -s)" == "Linux" ]] && [[ "x${BUILD_OFFLOAD}" != "xcpu" ]];
         then
-          # install PGI but do not source it
-          # the makefile will do it automatically
+          # install PGI locally
           ./scripts/install_hpc_sdk.sh </dev/null
+          # get the PGI compilers in the path and set NV_CXX
+          . ./setup_nv_compiler.sh
         fi
         df -h .
         if [[ "x${BUILD_OFFLOAD}" == "xcpu" ]];

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,7 +80,7 @@ jobs:
         env
         echo "=======  end env  ====="
         # all == build (shlib,bins,tests) and install
-        make clean && make_clean_install && make all
+        make clean && make clean_install && make all
         df -h .
     - name: Tests
       shell: bash -l {0}

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ clean:
 	-export BUILD_VARIANT=cpu_x86_v2; cd src && $(MAKE) clean
 	-export BUILD_VARIANT=cpu_x86_v3; cd src && $(MAKE) clean
 	-export BUILD_VARIANT=cpu_x86_v4; cd src && $(MAKE) clean
-	-. ./setup_nv_h5.sh; export BUILD_VARIANT=nv; cd src && $(MAKE) clean
+	-export BUILD_VARIANT=nv; cd src && $(MAKE) clean
 	-cd combined && $(MAKE) clean
 
 clean_install:
@@ -49,7 +49,7 @@ clean_install:
 	-export BUILD_VARIANT=cpu_x86_v2; cd src && $(MAKE) clean_install
 	-export BUILD_VARIANT=cpu_x86_v3; cd src && $(MAKE) clean_install
 	-export BUILD_VARIANT=cpu_x86_v4; cd src && $(MAKE) clean_install
-	-. ./setup_nv_h5.sh; export BUILD_VARIANT=nv; cd src && $(MAKE) clean_install
+	-export BUILD_VARIANT=nv; cd src && $(MAKE) clean_install
 	-cd combined && $(MAKE) clean_install
 
 else
@@ -116,7 +116,7 @@ api_cpu_x86_v4:
 	export BUILD_VARIANT=cpu_x86_v4 ; export BUILD_FULL_OPTIMIZATION=x86-64-v4 ; export BUILD_TUNE_OPTIMIZATION=znver4 ;cd src && $(MAKE) clean && $(MAKE) api
 
 api_nv:
-	. ./setup_nv_h5.sh; export BUILD_VARIANT=nv ; export BUILD_FULL_OPTIMIZATION=False ; cd src && $(MAKE) clean && $(MAKE) api_acc
+	export BUILD_VARIANT=nv ; export BUILD_FULL_OPTIMIZATION=False ; cd src && $(MAKE) clean && $(MAKE) api_acc
 
 api_combined:
 	cd combined && $(MAKE) clean && $(MAKE) api
@@ -147,7 +147,7 @@ install_cpu_x86_v4:
 	export BUILD_VARIANT=cpu_x86_v4 ; export BUILD_FULL_OPTIMIZATION=x86-64-v4 ; cd src && $(MAKE) install_lib
 
 install_nv:
-	. ./setup_nv_h5.sh; export BUILD_VARIANT=nv ; export BUILD_FULL_OPTIMIZATION=False ; cd src && $(MAKE) install_lib_acc
+	export BUILD_VARIANT=nv ; export BUILD_FULL_OPTIMIZATION=False ; cd src && $(MAKE) install_lib_acc
 
 install_combined:
 	cd combined && $(MAKE) install

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ else
 all: 
 	$(MAKE) all_cpu
 	$(MAKE) all_acc
+	$(MAKE) test_binaries
 
 clean:
 	$(MAKE) clean_cpu
@@ -40,7 +41,6 @@ all_cpu:
 	$(MAKE) all_cpu_x86_v3
 	$(MAKE) all_cpu_x86_v4
 	$(MAKE) all_combined
-	$(MAKE) test_binaries
 
 clean_cpu:
 	-cd test && $(MAKE) clean

--- a/Makefile
+++ b/Makefile
@@ -24,51 +24,41 @@ clean_install:
 else
 # Linux with several optimization levels and with optional GPU support
 
-ifndef NOGPU
-
 all: 
+	$(MAKE) all_cpu
+	if [ "x$${NV_CXX}" != "x" ]; then $(MAKE) all_nv; fi
+
+clean:
+	$(MAKE) clean_cpu
+	if [ "x$${NV_CXX}" != "x" ]; then export BUILD_VARIANT=nv; cd src && $(MAKE) clean; fi
+
+clean_install:
+	$(MAKE) clean_install_cpu
+	if [ "x$${NV_CXX}" != "x" ]; then export BUILD_VARIANT=nv; cd src && $(MAKE) clean_install; fi
+
+all_cpu: 
 	$(MAKE) all_cpu_basic
 	$(MAKE) all_cpu_x86_v2
 	$(MAKE) all_cpu_x86_v3
 	$(MAKE) all_cpu_x86_v4
-	$(MAKE) all_nv
 	$(MAKE) all_combined
 	$(MAKE) test_binaries
 
-clean:
+clean_cpu:
 	-cd test && $(MAKE) clean
 	-export BUILD_VARIANT=cpu_basic; cd src && $(MAKE) clean
 	-export BUILD_VARIANT=cpu_x86_v2; cd src && $(MAKE) clean
 	-export BUILD_VARIANT=cpu_x86_v3; cd src && $(MAKE) clean
 	-export BUILD_VARIANT=cpu_x86_v4; cd src && $(MAKE) clean
-	-export BUILD_VARIANT=nv; cd src && $(MAKE) clean
 	-cd combined && $(MAKE) clean
 
-clean_install:
+clean_install_cpu:
 	-export BUILD_VARIANT=cpu_basic; cd src && $(MAKE) clean_install
 	-export BUILD_VARIANT=cpu_x86_v2; cd src && $(MAKE) clean_install
 	-export BUILD_VARIANT=cpu_x86_v3; cd src && $(MAKE) clean_install
 	-export BUILD_VARIANT=cpu_x86_v4; cd src && $(MAKE) clean_install
 	-export BUILD_VARIANT=nv; cd src && $(MAKE) clean_install
 	-cd combined && $(MAKE) clean_install
-
-else
-
-all: 
-	$(MAKE) all_cpu_basic
-	$(MAKE) all_combined
-	$(MAKE) test_binaries
-
-clean:
-	-cd test && $(MAKE) clean
-	-export BUILD_VARIANT=cpu_basic; cd src && $(MAKE) clean
-	-cd combined && $(MAKE) clean
-
-clean_install:
-	-export BUILD_VARIANT=cpu_basic; cd src && $(MAKE) clean_install
-	-cd combined && $(MAKE) clean_install
-
-endif
 
 all_cpu_basic:
 	$(MAKE) api_cpu_basic

--- a/Makefile
+++ b/Makefile
@@ -26,15 +26,13 @@ else
 
 all: 
 	$(MAKE) all_cpu
-	if [ "x$${NV_CXX}" != "x" ]; then $(MAKE) all_nv; fi
+	$(MAKE) all_acc
 
 clean:
 	$(MAKE) clean_cpu
-	if [ "x$${NV_CXX}" != "x" ]; then export BUILD_VARIANT=nv; cd src && $(MAKE) clean; fi
 
 clean_install:
 	$(MAKE) clean_install_cpu
-	if [ "x$${NV_CXX}" != "x" ]; then export BUILD_VARIANT=nv; cd src && $(MAKE) clean_install; fi
 
 all_cpu: 
 	$(MAKE) all_cpu_basic
@@ -76,9 +74,9 @@ all_cpu_x86_v4:
 	$(MAKE) api_cpu_x86_v4
 	$(MAKE) install_cpu_x86_v4
 
-all_nv: 
-	$(MAKE) api_nv
-	$(MAKE) install_nv
+all_acc: 
+	$(MAKE) api_acc
+	$(MAKE) install_lib_acc
 
 all_combined:
 	$(MAKE) api_combined
@@ -105,8 +103,8 @@ api_cpu_x86_v3:
 api_cpu_x86_v4:
 	export BUILD_VARIANT=cpu_x86_v4 ; export BUILD_FULL_OPTIMIZATION=x86-64-v4 ; export BUILD_TUNE_OPTIMIZATION=znver4 ;cd src && $(MAKE) clean && $(MAKE) api
 
-api_nv:
-	export BUILD_VARIANT=nv ; export BUILD_FULL_OPTIMIZATION=False ; cd src && $(MAKE) clean && $(MAKE) api_acc
+api_acc:
+	export BUILD_FULL_OPTIMIZATION=False ; cd src && $(MAKE) clean && $(MAKE) api_acc
 
 api_combined:
 	cd combined && $(MAKE) clean && $(MAKE) api
@@ -136,8 +134,8 @@ install_cpu_x86_v3:
 install_cpu_x86_v4:
 	export BUILD_VARIANT=cpu_x86_v4 ; export BUILD_FULL_OPTIMIZATION=x86-64-v4 ; cd src && $(MAKE) install_lib
 
-install_nv:
-	export BUILD_VARIANT=nv ; export BUILD_FULL_OPTIMIZATION=False ; cd src && $(MAKE) install_lib_acc
+install_lib_acc:
+	export BUILD_FULL_OPTIMIZATION=False ; cd src && $(MAKE) install_lib_acc
 
 install_combined:
 	cd combined && $(MAKE) install

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ source setup_nv_compiler.sh
 ```
 
 For AMD-GPU-enabled code, you will need the [AOMP clang](https://github.com/ROCm/aomp) compiler, and is only supported on Linux.
-This helper script will download it, install it (at a system level) and setup the necessary environment:
+This helper script will download it, install it and setup the necessary environment:
 ```
 scripts/install_amd_clang.sh 
 source setup_amd_compiler.sh

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ source setup_amd_compiler.sh
 At this point, we recommend building with
 ```
 export PERFORMING_CONDA_BUILD=True
-make clean && make all
+make clean && make clean_install && make all
 ```
 (This will also install it in the conda location)
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,14 @@ For NVIDIA-GPU-enabled code, you will need the [NVIDIA HPC SDK](https://develope
 This helper script will download it, install it and setup the necessary environment:
 ```
 scripts/install_hpc_sdk.sh 
-source setup_nv_h5.sh
+source setup_nv_compiler.sh
+```
+
+For AMD-GPU-enabled code, you will need the [AOMP clang](https://github.com/ROCm/aomp) compiler, and is only supported on Linux.
+This helper script will download it, install it (at a system level) and setup the necessary environment:
+```
+scripts/install_amd_clang.sh 
+source setup_amd_compiler.sh
 ```
 
 If you prefer to build your HDF5 toolchain yourself,

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ conda activate unifrac-binaries
 ```
 
 For NVIDIA-GPU-enabled code, you will need the [NVIDIA HPC SDK](https://developer.nvidia.com/hpc-sdk) compiler, and is only supported on Linux.
+The NVIDIA GPU compilation requires the setting of the `NV_CXX` environment variable.
+
 This helper script will download it, install it and setup the necessary environment:
 ```
 scripts/install_hpc_sdk.sh 
@@ -80,6 +82,8 @@ source setup_nv_compiler.sh
 ```
 
 For AMD-GPU-enabled code, you will need the [AOMP clang](https://github.com/ROCm/aomp) compiler, and is only supported on Linux.
+The AMD GPU compilation requires the setting of the `AMD_CXX` environment variable.
+
 This helper script will download it, install it and setup the necessary environment:
 ```
 scripts/install_amd_clang.sh 

--- a/README.md
+++ b/README.md
@@ -55,14 +55,6 @@ conda activate unifrac
 
 To install, first the binary needs to be compiled. This assumes that the HDF5 toolchain and libraries are available.
 
-Assuming `h5c++` is in your path, the following should work:
-
-```
-make clean && make api && make main 
-#optionally
-make install
-```
-
 
 **Note**: if you are using [conda](https://docs.anaconda.com/miniconda/) we recommend installing HDF5 and related compiler using the
 `conda-forge` channel, for example:
@@ -94,7 +86,23 @@ scripts/install_amd_clang.sh
 source setup_amd_compiler.sh
 ```
 
-If you prefer to build your HDF5 toolchain yourself,
+At this point, we recommend building with
+```
+export PERFORMING_CONDA_BUILD=True
+make clean && make all
+```
+(This will also install it in the conda location)
+
+
+If you prefer avoiding conda, assuming `h5c++` is in your path, the following should work, too:
+
+```
+make clean && make api && make main 
+#optionally
+make install
+```
+
+Note: If you prefer to build your HDF5 toolchain yourself,
 more information about how to setup the 
 stack can be found [here](https://support.hdfgroup.org/HDF5/Tutor/compile.html).
 

--- a/scripts/install_amd_clang.sh
+++ b/scripts/install_amd_clang.sh
@@ -24,7 +24,8 @@ else
  osver=`cat /etc/os-release |awk '/^VERSION_ID=/{split($1,a,"="); split(a[2],b,"\""); print b[2]}'`
  if [ "x$dist" = "xUbuntu" ]; then
   if [ "x$osver" == "x22.04" ]; then
-    curl -L https://github.com/ROCm-Developer-Tools/aomp/releases/download/rel_${AOMP_VERSION}/aomp_Ubuntu2204_${AOMP_VERSION}_amd64.deb -o aomp_Ubuntu2204_${AOMP_VERSION}_amd64.deb
+    echo "[INFO] Fetching https://github.com/ROCm-Developer-Tools/aomp/releases/download/rel_${AOMP_VERSION}/aomp_Ubuntu2204_${AOMP_VERSION}_amd64.deb"
+    curl -s -L https://github.com/ROCm-Developer-Tools/aomp/releases/download/rel_${AOMP_VERSION}/aomp_Ubuntu2204_${AOMP_VERSION}_amd64.deb -o aomp_Ubuntu2204_${AOMP_VERSION}_amd64.deb
     if [ $? -ne 0 ]; then
       echo "Failed to download aomp_Ubuntu2204_${AOMP_VERSION}_amd64.deb"
       exit 1
@@ -34,7 +35,8 @@ else
     sudo apt install ./aomp_Ubuntu2204_${AOMP_VERSION}_amd64.deb
     rm -f aomp_Ubuntu2404_${AOMP_VERSION}_amd64.deb
   elif [ "x$osver" == "x24.04" ]; then
-    curl -L https://github.com/ROCm-Developer-Tools/aomp/releases/download/rel_${AOMP_VERSION}/aomp_Ubuntu2404_${AOMP_VERSION}_amd64.deb -o  aomp_Ubuntu2404_${AOMP_VERSION}_amd64.deb
+    echo "[INFO] Fetching https://github.com/ROCm-Developer-Tools/aomp/releases/download/rel_${AOMP_VERSION}/aomp_Ubuntu2404_${AOMP_VERSION}_amd64.deb"
+    curl -s -L https://github.com/ROCm-Developer-Tools/aomp/releases/download/rel_${AOMP_VERSION}/aomp_Ubuntu2404_${AOMP_VERSION}_amd64.deb -o  aomp_Ubuntu2404_${AOMP_VERSION}_amd64.deb
     if [ $? -ne 0 ]; then
       echo "Failed to download aomp_Ubuntu2404_${AOMP_VERSION}_amd64.deb"
       exit 1
@@ -54,6 +56,8 @@ else
 fi
 
 
+if [ -f /usr/lib/aomp_${AOMP_VERSION}/llvm/bin/amdclang++ ]; then
+
 cat > setup_amd_compiler.sh  << EOF
 export PATH=/usr/lib/aomp_${AOMP_VERSION}/:/usr/lib/aomp_${AOMP_VERSION}/bin/:/usr/lib/aomp_${AOMP_VERSION}/llvm/bin:\$PATH
 
@@ -67,7 +71,11 @@ export AMD_CFLAGS=
 export AMD_LDFLAGS=
 EOF
 
-# we don't need the install dir anymore
-rm -fr nvhpc_*
-
 echo "Setup script avaiabile in $PWD/setup_amd_compiler.sh"
+
+else
+  # something went wrong with the installation process above
+  echo "Failed to install aomp_${AOMP_VERSION}"
+  exit 1
+fi
+

--- a/scripts/install_amd_clang.sh
+++ b/scripts/install_amd_clang.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+#
+# This is a helper script for installing the AMD clang-based compiler
+# needed to compile a GPU-enabled version of unifrac.
+#
+# Note: The script currently assumes Linux_x86_64 platform.
+#
+
+# Note:
+# for the time being, it reuqires sudo access
+# as we do not support static linking, and thus must have abspaths
+
+#
+# based on https://github.com/ROCm/aomp/blob/aomp-dev/docs/INSTALL.md
+#
+
+export AOMP_VERSION=20.0-1
+
+if [ -f /usr/lib/aomp_${AOMP_VERSION}/llvm/bin/amdclang++ ]; then
+ dist=`cat /etc/os-release |awk '/^NAME=/{split($1,a,"="); split(a[2],b,"\""); print b[2]}'`
+ osver=`cat /etc/os-release |awk '/^VERSION_ID=/{split($1,a,"="); split(a[2],b,"\""); print b[2]}'`
+ if [ "x$dist" = "xUbuntu" ]; then
+  if [ "x$osver" == "x22.04" ]; then
+    wget https://github.com/ROCm-Developer-Tools/aomp/releases/download/rel_${AOMP_VERSION}/aomp_Ubuntu2204_${AOMP_VERSION}_amd64.deb
+    echo "[INFO] Executing sudo dpkg -i aomp_Ubuntu2204_${AOMP_VERSION}_amd64.deb"
+    echo "Please insert password, if you want to install aomp"
+    sudo dpkg -i aomp_Ubuntu2204_${AOMP_VERSION}_amd64.deb
+    rm -f aomp_Ubuntu2404_${AOMP_VERSION}_amd64.deb
+  elif [ "x$osver" == "x24.04" ]; then
+    wget https://github.com/ROCm-Developer-Tools/aomp/releases/download/rel_${AOMP_VERSION}/aomp_Ubuntu2404_${AOMP_VERSION}_amd64.deb
+    echo "[INFO] Executing sudo dpkg -i aomp_Ubuntu2404_${AOMP_VERSION}_amd64.deb"
+    echo "Please insert password, if you want to install aomp"
+    sudo dpkg -i aomp_Ubuntu2404_${AOMP_VERSION}_amd64.deb
+    rm -f aomp_Ubuntu2404_${AOMP_VERSION}_amd64.deb
+  else
+   echo "Unsupported $dist Linux version $osver"
+   exit 1
+  fi
+ else
+  echo "Unsupported Linux distribution $dist"
+  exit 1
+ fi
+else
+    echo "[INFO] Found existing /usr/lib/aomp_${AOMP_VERSION}/llvm/bin/amdclang++"
+fi
+
+
+cat > setup_amd_compiler.sh  << EOF
+export PATH=/usr/lib/aomp_${AOMP_VERSION}/:/usr/lib/aomp_${AOMP_VERSION}/bin/:/usr/lib/aomp_${AOMP_VERSION}/llvm/bin:\$PATH
+
+export AMD_CXX=amdclang++
+
+# no special  flags needed in most cases
+export AMD_CPPFLAGS=
+export AMD_CXXFLAGS=
+export AMD_CFLAGS=
+
+export AMD_LDFLAGS=
+EOF
+
+# we don't need the install dir anymore
+rm -fr nvhpc_*
+
+echo "Setup script avaiabile in $PWD/setup_amd_compiler.sh"

--- a/scripts/install_amd_clang.sh
+++ b/scripts/install_amd_clang.sh
@@ -24,24 +24,24 @@ else
  osver=`cat /etc/os-release |awk '/^VERSION_ID=/{split($1,a,"="); split(a[2],b,"\""); print b[2]}'`
  if [ "x$dist" = "xUbuntu" ]; then
   if [ "x$osver" == "x22.04" ]; then
-    curl https://github.com/ROCm-Developer-Tools/aomp/releases/download/rel_${AOMP_VERSION}/aomp_Ubuntu2204_${AOMP_VERSION}_amd64.deb -o aomp_Ubuntu2204_${AOMP_VERSION}_amd64.deb
+    curl -L https://github.com/ROCm-Developer-Tools/aomp/releases/download/rel_${AOMP_VERSION}/aomp_Ubuntu2204_${AOMP_VERSION}_amd64.deb -o aomp_Ubuntu2204_${AOMP_VERSION}_amd64.deb
     if [ $? -ne 0 ]; then
       echo "Failed to download aomp_Ubuntu2204_${AOMP_VERSION}_amd64.deb"
       exit 1
     fi
     echo "[INFO] Executing sudo dpkg -i aomp_Ubuntu2204_${AOMP_VERSION}_amd64.deb"
     echo "Please insert password, if you want to install aomp"
-    sudo dpkg -i aomp_Ubuntu2204_${AOMP_VERSION}_amd64.deb
+    sudo apt install ./aomp_Ubuntu2204_${AOMP_VERSION}_amd64.deb
     rm -f aomp_Ubuntu2404_${AOMP_VERSION}_amd64.deb
   elif [ "x$osver" == "x24.04" ]; then
-    curl https://github.com/ROCm-Developer-Tools/aomp/releases/download/rel_${AOMP_VERSION}/aomp_Ubuntu2404_${AOMP_VERSION}_amd64.deb -o  aomp_Ubuntu2404_${AOMP_VERSION}_amd64.deb
+    curl -L https://github.com/ROCm-Developer-Tools/aomp/releases/download/rel_${AOMP_VERSION}/aomp_Ubuntu2404_${AOMP_VERSION}_amd64.deb -o  aomp_Ubuntu2404_${AOMP_VERSION}_amd64.deb
     if [ $? -ne 0 ]; then
       echo "Failed to download aomp_Ubuntu2404_${AOMP_VERSION}_amd64.deb"
       exit 1
     fi
     echo "[INFO] Executing sudo dpkg -i aomp_Ubuntu2404_${AOMP_VERSION}_amd64.deb"
     echo "Please insert password, if you want to install aomp"
-    sudo dpkg -i aomp_Ubuntu2404_${AOMP_VERSION}_amd64.deb
+    sudo apt install ./aomp_Ubuntu2404_${AOMP_VERSION}_amd64.deb
     rm -f aomp_Ubuntu2404_${AOMP_VERSION}_amd64.deb
   else
    echo "Unsupported $dist Linux version $osver"

--- a/scripts/install_amd_clang.sh
+++ b/scripts/install_amd_clang.sh
@@ -24,13 +24,21 @@ else
  osver=`cat /etc/os-release |awk '/^VERSION_ID=/{split($1,a,"="); split(a[2],b,"\""); print b[2]}'`
  if [ "x$dist" = "xUbuntu" ]; then
   if [ "x$osver" == "x22.04" ]; then
-    wget https://github.com/ROCm-Developer-Tools/aomp/releases/download/rel_${AOMP_VERSION}/aomp_Ubuntu2204_${AOMP_VERSION}_amd64.deb
+    curl https://github.com/ROCm-Developer-Tools/aomp/releases/download/rel_${AOMP_VERSION}/aomp_Ubuntu2204_${AOMP_VERSION}_amd64.deb -o aomp_Ubuntu2204_${AOMP_VERSION}_amd64.deb
+    if [ $? -ne 0 ]; then
+      echo "Failed to download aomp_Ubuntu2204_${AOMP_VERSION}_amd64.deb"
+      exit 1
+    fi
     echo "[INFO] Executing sudo dpkg -i aomp_Ubuntu2204_${AOMP_VERSION}_amd64.deb"
     echo "Please insert password, if you want to install aomp"
     sudo dpkg -i aomp_Ubuntu2204_${AOMP_VERSION}_amd64.deb
     rm -f aomp_Ubuntu2404_${AOMP_VERSION}_amd64.deb
   elif [ "x$osver" == "x24.04" ]; then
-    wget https://github.com/ROCm-Developer-Tools/aomp/releases/download/rel_${AOMP_VERSION}/aomp_Ubuntu2404_${AOMP_VERSION}_amd64.deb
+    curl https://github.com/ROCm-Developer-Tools/aomp/releases/download/rel_${AOMP_VERSION}/aomp_Ubuntu2404_${AOMP_VERSION}_amd64.deb -o  aomp_Ubuntu2404_${AOMP_VERSION}_amd64.deb
+    if [ $? -ne 0 ]; then
+      echo "Failed to download aomp_Ubuntu2404_${AOMP_VERSION}_amd64.deb"
+      exit 1
+    fi
     echo "[INFO] Executing sudo dpkg -i aomp_Ubuntu2404_${AOMP_VERSION}_amd64.deb"
     echo "Please insert password, if you want to install aomp"
     sudo dpkg -i aomp_Ubuntu2404_${AOMP_VERSION}_amd64.deb

--- a/scripts/install_amd_clang.sh
+++ b/scripts/install_amd_clang.sh
@@ -18,6 +18,8 @@
 export AOMP_VERSION=20.0-1
 
 if [ -f /usr/lib/aomp_${AOMP_VERSION}/llvm/bin/amdclang++ ]; then
+ echo "[INFO] Found existing /usr/lib/aomp_${AOMP_VERSION}/llvm/bin/amdclang++"
+else
  dist=`cat /etc/os-release |awk '/^NAME=/{split($1,a,"="); split(a[2],b,"\""); print b[2]}'`
  osver=`cat /etc/os-release |awk '/^VERSION_ID=/{split($1,a,"="); split(a[2],b,"\""); print b[2]}'`
  if [ "x$dist" = "xUbuntu" ]; then
@@ -41,8 +43,6 @@ if [ -f /usr/lib/aomp_${AOMP_VERSION}/llvm/bin/amdclang++ ]; then
   echo "Unsupported Linux distribution $dist"
   exit 1
  fi
-else
-    echo "[INFO] Found existing /usr/lib/aomp_${AOMP_VERSION}/llvm/bin/amdclang++"
 fi
 
 

--- a/scripts/install_amd_clang.sh
+++ b/scripts/install_amd_clang.sh
@@ -17,8 +17,10 @@
 
 export AOMP_VERSION=20.0-1
 
-if [ -f /usr/lib/aomp_${AOMP_VERSION}/llvm/bin/amdclang++ ]; then
- echo "[INFO] Found existing /usr/lib/aomp_${AOMP_VERSION}/llvm/bin/amdclang++"
+export AOMP_BASEDIR=/usr/lib
+
+if [ -f ${AOMP_BASEDIR}/aomp_${AOMP_VERSION}/llvm/bin/amdclang++ ]; then
+ echo "[INFO] Found existing ${AOMP_BASEDIR}/aomp_${AOMP_VERSION}/llvm/bin/amdclang++"
 else
  dist=`cat /etc/os-release |awk '/^NAME=/{split($1,a,"="); split(a[2],b,"\""); print b[2]}'`
  osver=`cat /etc/os-release |awk '/^VERSION_ID=/{split($1,a,"="); split(a[2],b,"\""); print b[2]}'`
@@ -31,8 +33,14 @@ else
       exit 1
     fi
     echo "[INFO] Executing sudo dpkg -i aomp_Ubuntu2204_${AOMP_VERSION}_amd64.deb"
-    echo "Please insert password, if you want to install aomp"
+    echo "Please insert password, if you want to install aomp in /usr/lib"
     sudo apt install ./aomp_Ubuntu2204_${AOMP_VERSION}_amd64.deb
+    if [ $? -ne 0 ]; then
+      echo "[WARNING] System install failed, doing unprivileged install in $PWD/aomp_clang"
+      mkdir $PWD/aomp_clang
+      dpkg -x aomp_Ubuntu2204_${AOMP_VERSION}_amd64.deb $PWD/aomp_clang
+      AOMP_BASEDIR=$PWD/aomp_clang/usr/lib
+    fi
     rm -f aomp_Ubuntu2404_${AOMP_VERSION}_amd64.deb
   elif [ "x$osver" == "x24.04" ]; then
     echo "[INFO] Fetching https://github.com/ROCm-Developer-Tools/aomp/releases/download/rel_${AOMP_VERSION}/aomp_Ubuntu2404_${AOMP_VERSION}_amd64.deb"
@@ -42,8 +50,14 @@ else
       exit 1
     fi
     echo "[INFO] Executing sudo dpkg -i aomp_Ubuntu2404_${AOMP_VERSION}_amd64.deb"
-    echo "Please insert password, if you want to install aomp"
+    echo "Please insert password, if you want to install aomp in /usr/lib"
     sudo apt install ./aomp_Ubuntu2404_${AOMP_VERSION}_amd64.deb
+    if [ $? -ne 0 ]; then
+      echo "[WARNING] System install failed, doing unprivileged install in $PWD/aomp_clang"
+      mkdir $PWD/aomp_clang
+      dpkg -x aomp_Ubuntu2404_${AOMP_VERSION}_amd64.deb $PWD/aomp_clang
+      AOMP_BASEDIR=$PWD/aomp_clang/usr/lib
+    fi
     rm -f aomp_Ubuntu2404_${AOMP_VERSION}_amd64.deb
   else
    echo "Unsupported $dist Linux version $osver"
@@ -56,10 +70,10 @@ else
 fi
 
 
-if [ -f /usr/lib/aomp_${AOMP_VERSION}/llvm/bin/amdclang++ ]; then
+if [ -f ${AOMP_BASEDIR}/aomp_${AOMP_VERSION}/llvm/bin/amdclang++ ]; then
 
 cat > setup_amd_compiler.sh  << EOF
-export PATH=/usr/lib/aomp_${AOMP_VERSION}/:/usr/lib/aomp_${AOMP_VERSION}/bin/:/usr/lib/aomp_${AOMP_VERSION}/llvm/bin:\$PATH
+export PATH=${AOMP_BASEDIR}/aomp_${AOMP_VERSION}/:${AOMP_BASEDIR}/aomp_${AOMP_VERSION}/bin/:${AOMP_BASEDIR}/aomp_${AOMP_VERSION}/llvm/bin:\$PATH
 
 export AMD_CXX=amdclang++
 

--- a/scripts/install_hpc_sdk.sh
+++ b/scripts/install_hpc_sdk.sh
@@ -83,17 +83,6 @@ mkdir setup_scripts
 cat > setup_scripts/setup_nv_hpc_bins.sh << EOF
 PATH=$PWD/conda_nv_bins:`ls -d $PWD/hpc_sdk/*/202*/compilers/bin`:\$PATH
 
-export NV_CXX=pgc++
-
-# pgc++ does not define it, but gcc libraries expect it
-# also remove the existing conda flags, which are not compatible
-export NV_CPPFLAGS=-D__GCC_ATOMIC_TEST_AND_SET_TRUEVAL=0
-export NV_CXXFLAGS=\${NV_CPPFLAGS}
-export NV_CFLAGS=\${NV_CPPFLAGS}
-
-# reuse the same top-level LDFLAGS
-export NV_LDFLAGS=\${LDFLAGS}
-
 EOF
 
 # patch localrc to find crt1.o
@@ -104,13 +93,23 @@ for f in ${NVHPC_INSTALL_DIR}/*/202*/compilers/bin/localrc; do
   #echo "===="
 done
 
-# TODO: Get rid of this indirection
-cat > setup_nv_h5.sh  << EOF
+cat > setup_nv_compiler.sh  << EOF
 . $PWD/setup_scripts/setup_nv_hpc_bins.sh
+
+export NV_CXX=pgc++
+
+# no special  flags needed in most cases
+export NV_CPPFLAGS=
+export NV_CXXFLAGS=
+export NV_CFLAGS=
+
+# reuse the same top-level LDFLAGS
+# in order to find the right system shared libraries, etc.
+export NV_LDFLAGS=\${LDFLAGS}
 
 EOF
 
 # we don't need the install dir anymore
 rm -fr nvhpc_*
 
-echo "Setup script avaiabile in $PWD/setup_nv_h5.sh"
+echo "Setup script avaiabile in $PWD/setup_nv_compiler.sh"

--- a/scripts/install_hpc_sdk.sh
+++ b/scripts/install_hpc_sdk.sh
@@ -36,9 +36,9 @@ export PATH=$PWD/conda_nv_bins:$PATH
 # Install the NVIDIA HPC SDK
 
 # This link may need to be updated, as new compiler versions are released
-# Note: Verified that it works with v23.5
+# Note: Verified that it works with v25.1
 if [ "x${NV_URL}" == "x" ]; then
-  NV_URL=https://developer.download.nvidia.com/hpc-sdk/23.5/nvhpc_2023_235_Linux_x86_64_cuda_multi.tar.gz
+  NV_URL=https://developer.download.nvidia.com/hpc-sdk/25.1/nvhpc_2025_251_Linux_x86_64_cuda_multi.tar.gz
 fi
 
 echo "Downloading the NVIDIA HPC SDK"

--- a/src/Makefile
+++ b/src/Makefile
@@ -90,7 +90,6 @@ ifndef NOGPU
 		NV_LDFLAGS += -shared -mp=gpu -Bstatic_pgi
 	endif
    else 
-     ifeq ($(BUILD_NV_OFFLOAD),acc)
 	ifneq (,$(findstring pgi,$(NV_COMPILER)))
 		UNIFRAC_ACC_SHLIBS += libssu_acc_nv.so
 		NV_CPPFLAGS += -tp=px -acc
@@ -103,13 +102,11 @@ ifndef NOGPU
                 endif
 		NV_LDFLAGS += -shared -acc -Bstatic_pgi
 	endif
-     endif
    endif
    # AMD GPUs
    UNIFRAC_FILES += unifrac_task_acc_amd.o unifrac_cmp_acc_amd.o
    CPPFLAGS += -DUNIFRAC_ENABLE_ACC_AMD=1
-   ifeq ($(BUILD_AMD_OFFLOAD),ompgpu)
-	ifneq (,$(findstring clang,$(AMD_COMPILER)))
+   ifneq (,$(findstring clang,$(AMD_COMPILER)))
 		UNIFRAC_ACC_SHLIBS += libssu_acc_amd.so
 		AMD_CPPFLAGS += -fopenmp -fopenmp-offload-mandatory -DOMPGPU=1
 	        ifeq ($(PERFORMING_CONDA_BUILD),True)
@@ -118,7 +115,6 @@ ifndef NOGPU
 	            AMD_CPPFLAGS += --offload-arch=native
                 endif
 		AMD_LDFLAGS += -shared -fopenmp --offload-arch=gfx1100,gfx1101,gfx1102,gfx1103,gfx1030,gfx1031,gfx90a,gfx942
-	endif
    endif
 endif
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -66,7 +66,14 @@ else
    NV_COMPILER := $(shell ($(NV_CXX) -v 2>&1) | tr A-Z a-z )
 endif
 
+ifeq ($(AMD_CXX),)
+   AMD_COMPILER := 
+else
+   AMD_COMPILER := $(shell ($(AMD_CXX) -v 2>&1) | tr A-Z a-z )
+endif
+
 ifndef NOGPU
+   # NVIDIA GPUs
    UNIFRAC_FILES += unifrac_task_acc_nv.o unifrac_cmp_acc_nv.o
    CPPFLAGS += -DUNIFRAC_ENABLE_ACC_NV=1
    ifeq ($(BUILD_NV_OFFLOAD),ompgpu)
@@ -97,6 +104,21 @@ ifndef NOGPU
 		NV_LDFLAGS += -shared -acc -Bstatic_pgi
 	endif
      endif
+   endif
+   # AMD GPUs
+   UNIFRAC_FILES += unifrac_task_acc_amd.o unifrac_cmp_acc_amd.o
+   CPPFLAGS += -DUNIFRAC_ENABLE_ACC_AMD=1
+   ifeq ($(BUILD_AMD_OFFLOAD),ompgpu)
+	ifneq (,$(findstring clang,$(AMD_COMPILER)))
+		UNIFRAC_ACC_SHLIBS += libssu_acc_amd.so
+		AMD_CPPFLAGS += -fopenmp -fopenmp-offload-mandatory -DOMPGPU=1
+	        ifeq ($(PERFORMING_CONDA_BUILD),True)
+	            AMD_CPPFLAGS += --offload-arch=gfx1100,gfx1101,gfx1102,gfx1103,gfx1030,gfx1031,gfx90a,gfx942
+		else
+	            AMD_CPPFLAGS += --offload-arch=native
+                endif
+		AMD_LDFLAGS += -shared -fopenmp --offload-arch=gfx1100,gfx1101,gfx1102,gfx1103,gfx1030,gfx1031,gfx90a,gfx942
+	endif
    endif
 endif
 
@@ -147,7 +169,7 @@ endif
 
 CPPFLAGS += -Wall  -std=c++17 -pedantic -I. $(OPT) -fPIC -L$(PREFIX)/lib
 NV_CPPFLAGS += -std=c++17 -I. $(OPT) -fPIC -L$(PREFIX)/lib
-OMPGPUCPPFLAGS += -std=c++17 -I. $(OPT) -fPIC -L$(PREFIX)/lib
+AMD_CPPFLAGS += -std=c++17 -I. $(OPT) -fPIC -L$(PREFIX)/lib
 
 all: api install_lib main install
 
@@ -203,13 +225,12 @@ unifrac_task_api_acc_nv.cpp: unifrac_task_impl.hpp unifrac_task_api_acc_nv.h gen
 unifrac_task_noclass_acc_nv.cpp: unifrac_task_impl.hpp unifrac_task_api_acc_nv.h generate_unifrac_task_noclass.py
 	python3 generate_unifrac_task_noclass.py acc_nv indirect > $@
 
-#TODO: all ompgpu lines are currently useless... will fix in follow-up commits
-unifrac_task_api_ompgpu.h: unifrac_task_impl.hpp generate_unifrac_task_noclass.py
-	python3 generate_unifrac_task_noclass.py ompgpu api_h > $@
-unifrac_task_api_ompgpu.cpp: unifrac_task_impl.hpp unifrac_task_api_ompgpu.h generate_unifrac_task_noclass.py
-	python3 generate_unifrac_task_noclass.py ompgpu api > $@
-unifrac_task_noclass_ompgpu.cpp: unifrac_task_impl.hpp unifrac_task_api_ompgpu.h generate_unifrac_task_noclass.py
-	python3 generate_unifrac_task_noclass.py ompgpu indirect > $@
+unifrac_task_api_acc_amd.h: unifrac_task_impl.hpp generate_unifrac_task_noclass.py
+	python3 generate_unifrac_task_noclass.py acc_amd api_h > $@
+unifrac_task_api_acc_amd.cpp: unifrac_task_impl.hpp unifrac_task_api_acc_amd.h generate_unifrac_task_noclass.py
+	python3 generate_unifrac_task_noclass.py acc_amd api > $@
+unifrac_task_noclass_acc_amd.cpp: unifrac_task_impl.hpp unifrac_task_api_acc_amd.h generate_unifrac_task_noclass.py
+	python3 generate_unifrac_task_noclass.py acc_amd indirect > $@
 
 unifrac_task_cpu.o: unifrac_task_noclass_cpu.cpp unifrac_task_noclass.hpp unifrac_task_impl.hpp
 	h5c++ $(CPPFLAGS) -DSUCMP_NM=su_cpu -c $< -o $@
@@ -230,13 +251,14 @@ unifrac_task_api_acc_nv.o: unifrac_task_api_acc_nv.cpp unifrac_task_api_acc_nv.h
 libssu_acc_nv.so: unifrac_task_api_acc_nv.o
 	$(NV_CXX) $(NV_LDFLAGS) -o $@ unifrac_task_api_acc_nv.o
 
-unifrac_task_ompgpu.o: unifrac_task_noclass_ompgpu.cpp unifrac_task_noclass.hpp unifrac_task_api_ompgpu.h
-	h5c++ $(CPPFLAGS) -DSUCMP_NM=su_ompgpu -c $< -o $@
-unifrac_task_api_ompgpu.o: unifrac_task_api_ompgpu.cpp unifrac_task_api_ompgpu.h unifrac_task_impl.hpp
-	${OMPGPUCXX} $(OMPGPUCPPFLAGS) -DSUCMP_NM=su_ompgpu -c $< -o $@
 
-libssu_ompgpu.so: unifrac_task_api_ompgpu.o
-	${OMPGPUCXX} $(OMPGPULDDFLAGS) -o $@ unifrac_task_api_ompgpu.o
+unifrac_task_acc_amd.o: unifrac_task_noclass_acc_amd.cpp unifrac_task_noclass.hpp unifrac_task_api_acc_amd.h
+	h5c++ $(CPPFLAGS) -DSUCMP_NM=su_acc_amd -c $< -o $@
+unifrac_task_api_acc_amd.o: unifrac_task_api_acc_amd.cpp unifrac_task_api_acc_amd.h unifrac_task_impl.hpp
+	$(AMD_CXX) $(AMD_CPPFLAGS) -DSUCMP_NM=su_acc_amd -c $< -o $@
+
+libssu_acc_amd.so: unifrac_task_api_acc_amd.o
+	$(AMD_CXX) $(AMD_LDFLAGS) -o $@ unifrac_task_api_acc_amd.o
 
 
 unifrac_cmp_cpu.o: unifrac_cmp.cpp unifrac_cmp.hpp unifrac_internal.hpp unifrac.hpp unifrac_task.hpp unifrac_task_noclass.hpp biom_interface.hpp tree.hpp
@@ -244,8 +266,8 @@ unifrac_cmp_cpu.o: unifrac_cmp.cpp unifrac_cmp.hpp unifrac_internal.hpp unifrac.
 
 unifrac_cmp_acc_nv.o: unifrac_cmp.cpp unifrac_cmp.hpp unifrac_internal.hpp unifrac.hpp unifrac_task.hpp unifrac_task_noclass.hpp biom_interface.hpp tree.hpp
 	h5c++ $(CPPFLAGS) -DSUCMP_NM=su_acc_nv -c $< -o $@
-unifrac_cmp_ompgpu.o: unifrac_cmp.cpp unifrac_cmp.hpp unifrac_internal.hpp unifrac.hpp unifrac_task.hpp unifrac_task_noclass.hpp biom_interface.hpp tree.hpp
-	h5c++ $(CPPFLAGS) -DSUCMP_NM=su_ompgpu -c $< -o $@
+unifrac_cmp_acc_amd.o: unifrac_cmp.cpp unifrac_cmp.hpp unifrac_internal.hpp unifrac.hpp unifrac_task.hpp unifrac_task_noclass.hpp biom_interface.hpp tree.hpp
+	h5c++ $(CPPFLAGS) -DSUCMP_NM=su_acc_amd -c $< -o $@
 
 %.o: %.cpp %.hpp
 	h5c++ $(CPPFLAGS) -c $< -o $@

--- a/src/Makefile
+++ b/src/Makefile
@@ -66,7 +66,7 @@ else
 endif
 
 ifndef NOGPU
-   ifeq ($(BUILD_OFFLOAD),ompgpu)
+   ifeq ($(BUILD_NV_OFFLOAD),ompgpu)
 	CPPFLAGS += -DUNIFRAC_ENABLE_ACC_NV=1
 	UNIFRAC_FILES += unifrac_task_acc_nv.o unifrac_cmp_acc_nv.o
 	ifneq (,$(findstring pgi,$(NV_COMPILER)))
@@ -82,7 +82,7 @@ ifndef NOGPU
 		NV_LDFLAGS += -shared -mp=gpu -Bstatic_pgi
 	endif
    else 
-     ifeq ($(BUILD_OFFLOAD),acc)
+     ifeq ($(BUILD_NV_OFFLOAD),acc)
 	CPPFLAGS += -DUNIFRAC_ENABLE_ACC_NV=1
 	UNIFRAC_FILES += unifrac_task_acc_nv.o unifrac_cmp_acc_nv.o
 	ifneq (,$(findstring pgi,$(NV_COMPILER)))

--- a/src/Makefile
+++ b/src/Makefile
@@ -59,41 +59,43 @@ CPPFLAGS += $(MPFLAG)
 UNIFRAC_FILES = unifrac_internal.o unifrac_task_cpu.o unifrac_cmp_cpu.o
 UNIFRAC_ACC_SHLIBS =
 
-ifndef NOGPU
-   # assuming NV only GPU-enabled compiler available
+ifeq ($(NV_CXX),)
+   NV_COMPILER := 
+else
    NV_COMPILER := $(shell ($(NV_CXX) -v 2>&1) | tr A-Z a-z )
+endif
+
+ifndef NOGPU
    ifeq ($(BUILD_OFFLOAD),ompgpu)
-	CPPFLAGS += -DUNIFRAC_ENABLE_OMPGPU=1
-	UNIFRAC_FILES += unifrac_task_ompgpu.o unifrac_cmp_ompgpu.o
+	CPPFLAGS += -DUNIFRAC_ENABLE_ACC_NV=1
+	UNIFRAC_FILES += unifrac_task_acc_nv.o unifrac_cmp_acc_nv.o
 	ifneq (,$(findstring pgi,$(NV_COMPILER)))
-		OMPGPUCXX=$(NV_CXX)
-		UNIFRAC_ACC_SHLIBS += libssu_ompgpu.so
-		OMPGPUCPPFLAGS += -tp=px -mp=gpu -DOMPGPU=1 -noacc
+		UNIFRAC_ACC_SHLIBS += libssu_acc_nv.so
+		NV_CPPFLAGS += -tp=px -mp=gpu -DOMPGPU=1 -noacc
 	        ifeq ($(PERFORMING_CONDA_BUILD),True)
-	            OMPGPUCPPFLAGS += -gpu=ccall
+	            NV_CPPFLAGS += -gpu=ccall
 		else
-	            OMPGPUCPPFLAGS += -gpu=ccnative
+	            NV_CPPFLAGS += -gpu=ccnative
 		    # optional info
-		    OMPGPUCPPFLAGS += -Minfo=accel
+		    NV_CPPFLAGS += -Minfo=accel
                 endif
-		OMPGPULDDFLAGS := $(NV_LDFLAGS) -shared -mp=gpu -Bstatic_pgi
+		NV_LDFLAGS += -shared -mp=gpu -Bstatic_pgi
 	endif
    else 
      ifeq ($(BUILD_OFFLOAD),acc)
-	CPPFLAGS += -DUNIFRAC_ENABLE_ACC=1
-	UNIFRAC_FILES += unifrac_task_acc.o unifrac_cmp_acc.o
+	CPPFLAGS += -DUNIFRAC_ENABLE_ACC_NV=1
+	UNIFRAC_FILES += unifrac_task_acc_nv.o unifrac_cmp_acc_nv.o
 	ifneq (,$(findstring pgi,$(NV_COMPILER)))
-		ACCCXX=$(NV_CXX)
-		UNIFRAC_ACC_SHLIBS += libssu_acc.so
-		ACCCPPFLAGS += -tp=px -acc
+		UNIFRAC_ACC_SHLIBS += libssu_acc_nv.so
+		NV_CPPFLAGS += -tp=px -acc
 	        ifeq ($(PERFORMING_CONDA_BUILD),True)
-	            ACCCPPFLAGS += -gpu=ccall
+	            NV_CPPFLAGS += -gpu=ccall
 		else
-	            ACCCPPFLAGS += -gpu=ccnative
+	            NV_CPPFLAGS += -gpu=ccnative
 		    # optional info
-		    ACCCPPFLAGS += -Minfo=accel
+		    NV_CPPFLAGS += -Minfo=accel
                 endif
-		ACCLDDFLAGS := $(NV_LDFLAGS) -shared -acc -Bstatic_pgi
+		NV_LDFLAGS += -shared -acc -Bstatic_pgi
 	endif
      endif
    endif
@@ -145,7 +147,7 @@ endif
 
 
 CPPFLAGS += -Wall  -std=c++17 -pedantic -I. $(OPT) -fPIC -L$(PREFIX)/lib
-ACCCPPFLAGS += -std=c++17 -I. $(OPT) -fPIC -L$(PREFIX)/lib
+NV_CPPFLAGS += -std=c++17 -I. $(OPT) -fPIC -L$(PREFIX)/lib
 OMPGPUCPPFLAGS += -std=c++17 -I. $(OPT) -fPIC -L$(PREFIX)/lib
 
 all: api install_lib main install
@@ -195,13 +197,14 @@ unifrac_task_noclass_cpu.cpp: unifrac_task_impl.hpp generate_unifrac_task_noclas
 	# So no need for futher levels of indirection
 	python3 generate_unifrac_task_noclass.py cpu direct > $@
 
-unifrac_task_api_acc.h: unifrac_task_impl.hpp generate_unifrac_task_noclass.py
-	python3 generate_unifrac_task_noclass.py acc api_h > $@
-unifrac_task_api_acc.cpp: unifrac_task_impl.hpp unifrac_task_api_acc.h generate_unifrac_task_noclass.py
-	python3 generate_unifrac_task_noclass.py acc api > $@
-unifrac_task_noclass_acc.cpp: unifrac_task_impl.hpp unifrac_task_api_acc.h generate_unifrac_task_noclass.py
-	python3 generate_unifrac_task_noclass.py acc indirect > $@
+unifrac_task_api_acc_nv.h: unifrac_task_impl.hpp generate_unifrac_task_noclass.py
+	python3 generate_unifrac_task_noclass.py acc_nv api_h > $@
+unifrac_task_api_acc_nv.cpp: unifrac_task_impl.hpp unifrac_task_api_acc_nv.h generate_unifrac_task_noclass.py
+	python3 generate_unifrac_task_noclass.py acc_nv api > $@
+unifrac_task_noclass_acc_nv.cpp: unifrac_task_impl.hpp unifrac_task_api_acc_nv.h generate_unifrac_task_noclass.py
+	python3 generate_unifrac_task_noclass.py acc_nv indirect > $@
 
+#TODO: all ompgpu lines are currently useless... will fix in follow-up commits
 unifrac_task_api_ompgpu.h: unifrac_task_impl.hpp generate_unifrac_task_noclass.py
 	python3 generate_unifrac_task_noclass.py ompgpu api_h > $@
 unifrac_task_api_ompgpu.cpp: unifrac_task_impl.hpp unifrac_task_api_ompgpu.h generate_unifrac_task_noclass.py
@@ -211,19 +214,22 @@ unifrac_task_noclass_ompgpu.cpp: unifrac_task_impl.hpp unifrac_task_api_ompgpu.h
 
 unifrac_task_cpu.o: unifrac_task_noclass_cpu.cpp unifrac_task_noclass.hpp unifrac_task_impl.hpp
 	h5c++ $(CPPFLAGS) -DSUCMP_NM=su_cpu -c $< -o $@
+
+
+
 # no separate task_api 
 
 # create symlink to make R (and any autodeduct system) happy
 unifrac_task.cpp: unifrac_task_noclass_cpu.cpp
 	ln -s unifrac_task_noclass_cpu.cpp unifrac_task.cpp
 
-unifrac_task_acc.o: unifrac_task_noclass_acc.cpp unifrac_task_noclass.hpp unifrac_task_api_acc.h
-	h5c++ $(CPPFLAGS) -DSUCMP_NM=su_acc -c $< -o $@
-unifrac_task_api_acc.o: unifrac_task_api_acc.cpp unifrac_task_api_acc.h unifrac_task_impl.hpp
-	${ACCCXX} $(ACCCPPFLAGS) -DSUCMP_NM=su_acc -c $< -o $@
+unifrac_task_acc_nv.o: unifrac_task_noclass_acc_nv.cpp unifrac_task_noclass.hpp unifrac_task_api_acc_nv.h
+	h5c++ $(CPPFLAGS) -DSUCMP_NM=su_acc_nv -c $< -o $@
+unifrac_task_api_acc_nv.o: unifrac_task_api_acc_nv.cpp unifrac_task_api_acc_nv.h unifrac_task_impl.hpp
+	$(NV_CXX) $(NV_CPPFLAGS) -DSUCMP_NM=su_acc_nv -c $< -o $@
 
-libssu_acc.so: unifrac_task_api_acc.o
-	${ACCCXX} $(ACCLDDFLAGS) -o $@ unifrac_task_api_acc.o
+libssu_acc_nv.so: unifrac_task_api_acc_nv.o
+	$(NV_CXX) $(NV_LDFLAGS) -o $@ unifrac_task_api_acc_nv.o
 
 unifrac_task_ompgpu.o: unifrac_task_noclass_ompgpu.cpp unifrac_task_noclass.hpp unifrac_task_api_ompgpu.h
 	h5c++ $(CPPFLAGS) -DSUCMP_NM=su_ompgpu -c $< -o $@
@@ -237,8 +243,8 @@ libssu_ompgpu.so: unifrac_task_api_ompgpu.o
 unifrac_cmp_cpu.o: unifrac_cmp.cpp unifrac_cmp.hpp unifrac_internal.hpp unifrac.hpp unifrac_task.hpp unifrac_task_noclass.hpp biom_interface.hpp tree.hpp
 	h5c++ $(CPPFLAGS) -DSUCMP_NM=su_cpu -c $< -o $@
 
-unifrac_cmp_acc.o: unifrac_cmp.cpp unifrac_cmp.hpp unifrac_internal.hpp unifrac.hpp unifrac_task.hpp unifrac_task_noclass.hpp biom_interface.hpp tree.hpp
-	h5c++ $(CPPFLAGS) -DSUCMP_NM=su_acc -c $< -o $@
+unifrac_cmp_acc_nv.o: unifrac_cmp.cpp unifrac_cmp.hpp unifrac_internal.hpp unifrac.hpp unifrac_task.hpp unifrac_task_noclass.hpp biom_interface.hpp tree.hpp
+	h5c++ $(CPPFLAGS) -DSUCMP_NM=su_acc_nv -c $< -o $@
 unifrac_cmp_ompgpu.o: unifrac_cmp.cpp unifrac_cmp.hpp unifrac_internal.hpp unifrac.hpp unifrac_task.hpp unifrac_task_noclass.hpp biom_interface.hpp tree.hpp
 	h5c++ $(CPPFLAGS) -DSUCMP_NM=su_ompgpu -c $< -o $@
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -39,6 +39,7 @@ BLASLIB=-llapacke -lcblas
 ifeq ($(PLATFORM),Darwin)
 	AVX2 := $(shell sysctl -a | grep -c AVX2)
 	LDDFLAGS = -dynamiclib -install_name @rpath/lib$(SSU).so
+	NOGPU := 1
 else
 	AVX2 := $(shell grep "^flags" /proc/cpuinfo | head -n 1 | grep -c avx2)
 	LDDFLAGS = -shared
@@ -66,9 +67,9 @@ else
 endif
 
 ifndef NOGPU
+   UNIFRAC_FILES += unifrac_task_acc_nv.o unifrac_cmp_acc_nv.o
+   CPPFLAGS += -DUNIFRAC_ENABLE_ACC_NV=1
    ifeq ($(BUILD_NV_OFFLOAD),ompgpu)
-	CPPFLAGS += -DUNIFRAC_ENABLE_ACC_NV=1
-	UNIFRAC_FILES += unifrac_task_acc_nv.o unifrac_cmp_acc_nv.o
 	ifneq (,$(findstring pgi,$(NV_COMPILER)))
 		UNIFRAC_ACC_SHLIBS += libssu_acc_nv.so
 		NV_CPPFLAGS += -tp=px -mp=gpu -DOMPGPU=1 -noacc
@@ -83,8 +84,6 @@ ifndef NOGPU
 	endif
    else 
      ifeq ($(BUILD_NV_OFFLOAD),acc)
-	CPPFLAGS += -DUNIFRAC_ENABLE_ACC_NV=1
-	UNIFRAC_FILES += unifrac_task_acc_nv.o unifrac_cmp_acc_nv.o
 	ifneq (,$(findstring pgi,$(NV_COMPILER)))
 		UNIFRAC_ACC_SHLIBS += libssu_acc_nv.so
 		NV_CPPFLAGS += -tp=px -acc

--- a/src/unifrac.cpp
+++ b/src/unifrac.cpp
@@ -445,10 +445,16 @@ inline void check_acc() {
  }
 
  if (print_info) {
-   if (detected_acc != ACC_CPU) {
-     printf("INFO (unifrac): Using GPU\n");
-   } else {
-     printf("INFO (unifrac): Using CPU, not GPU\n");
+   if (detected_acc == ACC_CPU) {
+     printf("INFO (unifrac): Using CPU (not GPU)\n");
+#if defined(UNIFRAC_ENABLE_ACC_NV)
+   } else if (detected_acc == ACC_NV) {
+     printf("INFO (unifrac): Using NVIDIA GPU\n");
+#endif
+#if defined(UNIFRAC_ENABLE_ACC_AMD)
+   } else if (detected_acc == ACC_AMD) {
+     printf("INFO (unifrac): Using AMD GPU\n");
+#endif
    }
  }
  // we can assume int is atomic

--- a/src/unifrac.cpp
+++ b/src/unifrac.cpp
@@ -26,19 +26,20 @@
 #define SUCMP_NM  su_cpu
 #include "unifrac_cmp.hpp"
 #undef SUCMP_NM
+static constexpr int ACC_CPU=0;
 
-#ifdef UNIFRAC_ENABLE_ACC
-#define SUCMP_NM  su_acc
+#ifdef UNIFRAC_ENABLE_ACC_NV
+#define SUCMP_NM  su_acc_nv
 #include "unifrac_cmp.hpp"
 #undef SUCMP_NM
+static constexpr int ACC_NV=1;
 #endif
 
-#ifdef UNIFRAC_ENABLE_OMPGPU
-#define OMPGPU
-#define SUCMP_NM  su_ompgpu
+#ifdef UNIFRAC_ENABLE_ACC_AMD
+#define SUCMP_NM  su_acc_amd
 #include "unifrac_cmp.hpp"
 #undef SUCMP_NM
-#undef OMPGPU
+static constexpr int ACC_AMD=2;
 #endif
 
 using namespace su;
@@ -387,54 +388,11 @@ void su::faith_pd(biom_interface &table,
 }
 
 
-#ifdef UNIFRAC_ENABLE_OMPGPU
-
-// test only once, then use persistent value
-static int proc_use_ompgpu = -1;
-
-inline bool use_ompgpu() {
- if (proc_use_ompgpu!=-1) return (proc_use_ompgpu!=0);
-
- bool print_info = false;
-
- if (const char* env_p = std::getenv("UNIFRAC_GPU_INFO")) {
-   print_info = true;
-   std::string env_s(env_p);
-   if ((env_s=="NO") || (env_s=="N") || (env_s=="no") || (env_s=="n") ||
-       (env_s=="NEVER") || (env_s=="never")) {
-     print_info = false;
-   }
- }
-
- if (!su_ompgpu::found_gpu()) {
-   if (print_info) printf("INFO (unifrac): GPU not found, using CPU\n");
-   proc_use_ompgpu=0;
-   return false;
- }
-
- if (const char* env_p = std::getenv("UNIFRAC_USE_GPU")) {
-   std::string env_s(env_p);
-   if ((env_s=="NO") || (env_s=="N") || (env_s=="no") || (env_s=="n") ||
-       (env_s=="NEVER") || (env_s=="never")) {
-     if (print_info) printf("INFO (unifrac): Use of GPU explicitly disabled, using CPU\n");
-     proc_use_ompgpu=0;
-     return false;
-   }
- }
-
- if (print_info) printf("INFO (unifrac): Using GPU\n");
- proc_use_ompgpu=1;
- return true;
-}
-#endif
-
-#ifdef UNIFRAC_ENABLE_ACC
-
 // test only once, then use persistent value
 static int proc_use_acc = -1;
 
-inline bool use_acc() {
- if (proc_use_acc!=-1) return (proc_use_acc!=0);
+inline void check_acc() {
+ if (proc_use_acc!=-1) return; // keep the cached version
 
  bool print_info = false;
 
@@ -447,27 +405,41 @@ inline bool use_acc() {
    }
  }
 
- if (!su_acc::found_gpu()) {
-   if (print_info) printf("INFO (unifrac): GPU not found, using CPU\n");
-   proc_use_acc=0;
-   return false;
+ int detected_acc = ACC_CPU;
+#if defined(UNIFRAC_ENABLE_ACC_NV)
+ if ((detected_acc==ACC_CPU) && (su_acc_nv::found_gpu())) {
+   detected_acc = ACC_NV;
+   if (print_info) printf("INFO (unifrac): NVIDIA GPU detected\n");
  }
+#endif
+#if defined(UNIFRAC_ENABLE_ACC_AMD)
+ if ((detected_acc==ACC_CPU) && (su_acc_amd::found_gpu())) {
+   detected_acc = ACC_AMD;
+   if (print_info) printf("INFO (unifrac): AMD GPU detected\n");
+ }
+#endif
 
  if (const char* env_p = std::getenv("UNIFRAC_USE_GPU")) {
    std::string env_s(env_p);
    if ((env_s=="NO") || (env_s=="N") || (env_s=="no") || (env_s=="n") ||
        (env_s=="NEVER") || (env_s=="never")) {
-     if (print_info) printf("INFO (unifrac): Use of GPU explicitly disabled, using CPU\n");
-     proc_use_acc=0;
-     return false;
+     if (detected_acc!=ACC_CPU) {
+        if (print_info) printf("INFO (unifrac): GPU was detected but use explicitly disabled\n");
+         detected_acc = ACC_CPU;
+     }
    }
  }
 
- if (print_info) printf("INFO (unifrac): Using GPU\n");
- proc_use_acc=1;
- return true;
+ if (print_info) {
+   if (detected_acc != ACC_CPU) {
+     printf("INFO (unifrac): Using GPU\n");
+   } else {
+     printf("INFO (unifrac): Using CPU, not GPU\n");
+   }
+ }
+ // we can assume int is atomic
+ proc_use_acc = detected_acc;
 }
-#endif
 
 void su::unifrac(biom_interface &table,
                  BPTree &tree,
@@ -475,19 +447,17 @@ void su::unifrac(biom_interface &table,
                  std::vector<double*> &dm_stripes,
                  std::vector<double*> &dm_stripes_total,
                  const su::task_parameters* task_p) {
-#if defined(UNIFRAC_ENABLE_OMPGPU)
-  if (use_ompgpu()) {
-    su_ompgpu::unifrac(table, tree, unifrac_method, dm_stripes, dm_stripes_total, task_p);
-  } else {
-#elif defined(UNIFRAC_ENABLE_ACC)
-  // TODO: Should we support both OMPGPU and ACC at the same time?
-  if (use_acc()) {
-    su_acc::unifrac(table, tree, unifrac_method, dm_stripes, dm_stripes_total, task_p);
-  } else {
-#else
-  if (true) {
-#endif
+  check_acc();
+  if (proc_use_acc==ACC_CPU) {
     su_cpu::unifrac(table, tree, unifrac_method, dm_stripes, dm_stripes_total, task_p);
+#if defined(UNIFRAC_ENABLE_ACC_NV)
+  } else if (proc_use_acc==ACC_NV) {
+    su_acc_nv::unifrac(table, tree, unifrac_method, dm_stripes, dm_stripes_total, task_p);
+#endif
+#if defined(UNIFRAC_ENABLE_ACC_AMD)
+  } else if (proc_use_acc==ACC_AMD) {
+    su_acc_amd::unifrac(table, tree, unifrac_method, dm_stripes, dm_stripes_total, task_p);
+#endif
   }
 }
 
@@ -498,19 +468,17 @@ void su::unifrac_vaw(biom_interface &table,
                      std::vector<double*> &dm_stripes,
                      std::vector<double*> &dm_stripes_total,
                      const su::task_parameters* task_p) {
-#if defined(UNIFRAC_ENABLE_OMPGPU)
-  if (use_ompgpu()) {
-   su_ompgpu::unifrac_vaw(table, tree, unifrac_method, dm_stripes, dm_stripes_total, task_p);
-  } else {
-#elif defined(UNIFRAC_ENABLE_ACC)
-  // TODO: Should we support both OMPGPU and ACC at the same time?
-  if (use_acc()) {
-   su_acc::unifrac_vaw(table, tree, unifrac_method, dm_stripes, dm_stripes_total, task_p);
-  } else {
-#else
-  if (true) {
-#endif
+  check_acc();
+  if (proc_use_acc==ACC_CPU) {
    su_cpu::unifrac_vaw(table, tree, unifrac_method, dm_stripes, dm_stripes_total, task_p);
+#if defined(UNIFRAC_ENABLE_ACC_NV)
+  } else if (proc_use_acc==ACC_NV) {
+   su_acc_nv::unifrac_vaw(table, tree, unifrac_method, dm_stripes, dm_stripes_total, task_p);
+#endif
+#if defined(UNIFRAC_ENABLE_ACC_AMD)
+  } else if (proc_use_acc==ACC_AMD) {
+   su_acc_amd::unifrac_vaw(table, tree, unifrac_method, dm_stripes, dm_stripes_total, task_p);
+#endif
   }
 }
 

--- a/src/unifrac.cpp
+++ b/src/unifrac.cpp
@@ -417,6 +417,14 @@ inline void check_acc() {
  }
  if ((detected_acc==ACC_CPU) && detected_nv_acc) {
    detected_acc = ACC_NV;
+   if (const char* env_p = std::getenv("UNIFRAC_USE_NVIDIA_GPU")) {
+     std::string env_s(env_p);
+     if ((env_s=="NO") || (env_s=="N") || (env_s=="no") || (env_s=="n") ||
+         (env_s=="NEVER") || (env_s=="never")) {
+       if (print_info) printf("INFO (unifrac): NVIDIA GPU was detected but use explicitly disabled\n");
+       detected_acc = ACC_CPU;
+     }
+   }
  }
 #endif
 #if defined(UNIFRAC_ENABLE_ACC_AMD)
@@ -430,6 +438,14 @@ inline void check_acc() {
  }
  if ((detected_acc==ACC_CPU) && detected_amd_acc) {
    detected_acc = ACC_AMD;
+   if (const char* env_p = std::getenv("UNIFRAC_USE_AMD_GPU")) {
+     std::string env_s(env_p);
+     if ((env_s=="NO") || (env_s=="N") || (env_s=="no") || (env_s=="n") ||
+         (env_s=="NEVER") || (env_s=="never")) {
+       if (print_info) printf("INFO (unifrac): AMD GPU was detected but use explicitly disabled\n");
+       detected_acc = ACC_CPU;
+     }
+   }
  }
 #endif
 

--- a/src/unifrac.cpp
+++ b/src/unifrac.cpp
@@ -407,15 +407,29 @@ inline void check_acc() {
 
  int detected_acc = ACC_CPU;
 #if defined(UNIFRAC_ENABLE_ACC_NV)
- if ((detected_acc==ACC_CPU) && (su_acc_nv::found_gpu())) {
+ bool detected_nv_acc = su_acc_nv::found_gpu();
+ if (print_info) {
+   if (detected_nv_acc) {
+     printf("INFO (unifrac): NVIDIA GPU detected\n");
+   } else {
+     printf("INFO (unifrac): NVIDIA GPU not detected\n");
+   }
+ }
+ if ((detected_acc==ACC_CPU) && detected_nv_acc) {
    detected_acc = ACC_NV;
-   if (print_info) printf("INFO (unifrac): NVIDIA GPU detected\n");
  }
 #endif
 #if defined(UNIFRAC_ENABLE_ACC_AMD)
- if ((detected_acc==ACC_CPU) && (su_acc_amd::found_gpu())) {
+ bool detected_amd_acc = su_acc_amd::found_gpu();
+ if (print_info) {
+   if (detected_amd_acc) {
+     printf("INFO (unifrac): AMD GPU detected\n");
+   } else {
+     printf("INFO (unifrac): AMD GPU not detected\n");
+   }
+ }
+ if ((detected_acc==ACC_CPU) && detected_amd_acc) {
    detected_acc = ACC_AMD;
-   if (print_info) printf("INFO (unifrac): AMD GPU detected\n");
  }
 #endif
 


### PR DESCRIPTION
The NV and AMD GPU code now each have their own shared library.
The two can co-exist, and the code will use whichever GPU is available.

Note: The GPU code can be compiled independently of the CPU code, and installed separately, too.
The default behavior is to try to use the GPU libraries, if available, but gracefully proceed with CPU-only execution if such library have not been installed.
