### PR TITLE
Group k for Unweighted on GPU

### DIFF
--- a/src/unifrac_task.hpp
+++ b/src/unifrac_task.hpp
@@ -515,10 +515,12 @@ namespace SUCMP_NM {
           const unsigned int n_samples = this->task_p->n_samples;
           const unsigned int bsize = _max_embs*(0x400/32);
           zcheck = (bool*) malloc(sizeof(bool) * n_samples);
+          idxs = (uint32_t*) malloc(sizeof(uint32_t) * n_samples);
           stripe_sums = (TFloat*) malloc(sizeof(TFloat) *  n_samples);
           sums = (TFloat*) malloc(sizeof(TFloat) * bsize);
 
           acc_create_buf(zcheck, 0, n_samples);
+          acc_create_buf(idxs, 0, n_samples);
           acc_create_buf(stripe_sums, 0 , n_samples);
           acc_create_buf(sums, 0 , bsize);
         }
@@ -530,10 +532,12 @@ namespace SUCMP_NM {
 
           acc_destroy_buf(sums, 0 , bsize);
           acc_destroy_buf(stripe_sums, 0 , n_samples);
+          acc_destroy_buf(idxs, 0, n_samples);
           acc_destroy_buf(zcheck, 0, n_samples);
 
           free(sums);
           free(stripe_sums);
+          free(idxs);
           free(zcheck);
         }
 
@@ -541,6 +545,7 @@ namespace SUCMP_NM {
         // temp buffers
         TFloat *sums;
         bool     *zcheck;
+        uint32_t *idxs;  // assuming n_samples si really a uint32_t number
         TFloat   *stripe_sums;
     };
     template<class TFloat>
@@ -561,7 +566,7 @@ namespace SUCMP_NM {
 			 this->get_emb_els(this->max_embs), filled_embs,
 			 this->task_p->start, this->task_p->stop, this->task_p->n_samples, this->dm_stripes.n_samples_r,
 			 this->lengths, this->get_embedded_proportions(), this->dm_stripes.buf, this->dm_stripes_total.buf,
-			 this->sums, this->zcheck, this->stripe_sums);
+			 this->sums, this->zcheck, this->idxs, this->stripe_sums);
 
           // next iteration will use the alternative space
           this->set_alt_embedded_proportions();
@@ -586,7 +591,7 @@ namespace SUCMP_NM {
 			  this->task_p->start, this->task_p->stop, this->task_p->n_samples, this->dm_stripes.n_samples_r,
 			  this->lengths, this->get_embedded_proportions(),
 			  this->dm_stripes.buf,
-			  this->sums, this->zcheck, this->stripe_sums);
+			  this->sums, this->zcheck, this->idxs, this->stripe_sums);
 
           // next iteration will use the alternative space
           this->set_alt_embedded_proportions();

--- a/src/unifrac_task.hpp
+++ b/src/unifrac_task.hpp
@@ -515,14 +515,18 @@ namespace SUCMP_NM {
           const unsigned int n_samples = this->task_p->n_samples;
           const unsigned int bsize = _max_embs*(0x400/32);
           zcheck = (bool*) malloc(sizeof(bool) * n_samples);
-          idxs = (uint32_t*) malloc(sizeof(uint32_t) * n_samples);
           stripe_sums = (TFloat*) malloc(sizeof(TFloat) *  n_samples);
           sums = (TFloat*) malloc(sizeof(TFloat) * bsize);
 
           acc_create_buf(zcheck, 0, n_samples);
-          acc_create_buf(idxs, 0, n_samples);
           acc_create_buf(stripe_sums, 0 , n_samples);
           acc_create_buf(sums, 0 , bsize);
+#if SUCMP_ID(SUCMP_NM)==su_cpu_SUCMP_ID
+	  idxs = NULL; // not used in the CPU code
+#else
+          idxs = (uint32_t*) malloc(sizeof(uint32_t) * n_samples);
+          acc_create_buf(idxs, 0, n_samples);
+#endif
         }
 
         virtual ~UnifracCommonUnweightedTask()
@@ -530,14 +534,18 @@ namespace SUCMP_NM {
           const unsigned int n_samples = this->task_p->n_samples;
           const unsigned int bsize = this->max_embs*(0x400/32);
 
+#if SUCMP_ID(SUCMP_NM)==su_cpu_SUCMP_ID
+	  // not allocated in the CPU code
+#else
+          acc_destroy_buf(idxs, 0, n_samples);
+          free(idxs);
+#endif
           acc_destroy_buf(sums, 0 , bsize);
           acc_destroy_buf(stripe_sums, 0 , n_samples);
-          acc_destroy_buf(idxs, 0, n_samples);
           acc_destroy_buf(zcheck, 0, n_samples);
 
           free(sums);
           free(stripe_sums);
-          free(idxs);
           free(zcheck);
         }
 

--- a/src/unifrac_task_impl.hpp
+++ b/src/unifrac_task_impl.hpp
@@ -1473,7 +1473,7 @@ static inline uint32_t UnweightedZerosAndSums(
 	    if (all_zeros) n_true_idxs++;
     }
 
-#if !defined(OMPGPU) && defined(_OPENACC)
+#if defined(OMPGPU) || defined(_OPENACC)
     // create index of k, first all of those with zcheck true, then all false
     // equivalent to stable_sort, but knowing in advance n_true_idxs
 #if defined(OMPGPU)

--- a/src/unifrac_task_impl.hpp
+++ b/src/unifrac_task_impl.hpp
@@ -1,3 +1,12 @@
+/*
+ * BSD 3-Clause License
+ *
+ * Copyright (c) 2016-2025, UniFrac development team.
+ * All rights reserved.
+ *
+ * See LICENSE file for more details
+ */
+
 #include <math.h> 
 #include <algorithm> 
 #include "unifrac_task_noclass.hpp"
@@ -1593,6 +1602,11 @@ static inline void run_UnweightedTask_T(
 
     // point of thread
 #if defined(_OPENACC) || defined(OMPGPU)
+
+    // With idxs ordered, keep elements with same zcheck_k together
+    // This minimizes warp divergence, which is important given drastically different cost of some paths
+    // It does potentially disrupt memory coalescence, but the major memory cost is access to su, which is pseudo-random anyway
+    // (Note that sorting is not affective for the Weighted methods, since they have a much more regular memory access pattern)
 #if defined(OMPGPU)
     // TODO: Explore async omp target
 #pragma omp target teams distribute parallel for simd collapse(3) default(shared)
@@ -1754,6 +1768,10 @@ static inline void run_UnnormalizedUnweightedTask_T(
 
     // point of thread
 #if defined(_OPENACC) || defined(OMPGPU)
+    // With idxs ordered, keep elements with same zcheck_k together
+    // This minimizes warp divergence, which is important given drastically different cost of some paths
+    // It does potentially disrupt memory coalescence, but the major memory cost is access to su, which is pseudo-random anyway
+    // (Note that sorting is not affective for the Weighted methods, since they have a much more regular memory access pattern)
 #if defined(OMPGPU)
     // TODO: Explore async omp target
 #pragma omp target teams distribute parallel for simd collapse(3) default(shared)

--- a/src/unifrac_task_noclass.hpp
+++ b/src/unifrac_task_noclass.hpp
@@ -1,12 +1,20 @@
 /*
  * BSD 3-Clause License
  *
- * Copyright (c) 2025-2025, UniFrac development team.
+ * Copyright (c) 2016-2025, UniFrac development team.
  * All rights reserved.
  *
  * See LICENSE file for more details
  */
 
+/*
+ *
+ * This file is used to create the necessary interfaces between
+ *   unifrac_task.hpp and unifrac_task_impl.hpp
+ * by means of
+ *   generate_unifrac_task_noclass.py
+ *
+ */
 
 #ifndef __UNIFRAC_TASK_NOCLASS
 #define __UNIFRAC_TASK_NOCLASS 1

--- a/src/unifrac_task_noclass.hpp
+++ b/src/unifrac_task_noclass.hpp
@@ -114,6 +114,7 @@ namespace SUCMP_NM {
 		TFloat * const __restrict__ dm_stripes_total_buf,
 		TFloat * const __restrict__ sums,
 		bool   * const __restrict__ zcheck,
+		uint32_t* const __restrict__ idxs,
 		TFloat * const __restrict__ stripe_sums);
 
     // Compute UnnormalizedUnweighted step
@@ -128,6 +129,7 @@ namespace SUCMP_NM {
 		TFloat * const __restrict__ dm_stripes_buf,
 		TFloat * const __restrict__ sums,
 		bool   * const __restrict__ zcheck,
+		uint32_t* const __restrict__ idxs,
 		TFloat * const __restrict__ stripe_sums);
 
     // Compute Generalized step


### PR DESCRIPTION
By grouping indexes that have zero-sum, we minimize divergence of GPU warps.
This gives a noticeable speedup in Unweighted (due to expensive pseudo-random lookup for some paths).
Not done for Weighted, since it uses a more regular memory pattern that would be disrupted by grouping.